### PR TITLE
support localhost subdomains

### DIFF
--- a/src/ue/scaffold.js
+++ b/src/ue/scaffold.js
@@ -25,6 +25,7 @@ export function getUEHtmlHeadEntries(daCtx, aemCtx) {
     ref,
     path,
     isLocal,
+    orgSiteInPath,
   } = daCtx;
   const { ueHostname, ueService } = aemCtx;
   const children = [];
@@ -51,7 +52,7 @@ export function getUEHtmlHeadEntries(daCtx, aemCtx) {
   children.push(
     h('script', {
       type: 'application/vnd.adobe.aue.component+json',
-      src: isLocal
+      src: orgSiteInPath
         ? `/${org}/${site}/component-definition.json`
         : '/component-definition.json',
     }),
@@ -59,7 +60,7 @@ export function getUEHtmlHeadEntries(daCtx, aemCtx) {
   children.push(
     h('script', {
       type: 'application/vnd.adobe.aue.model+json',
-      src: isLocal
+      src: orgSiteInPath
         ? `/${org}/${site}/component-models.json`
         : '/component-models.json',
     }),
@@ -67,7 +68,7 @@ export function getUEHtmlHeadEntries(daCtx, aemCtx) {
   children.push(
     h('script', {
       type: 'application/vnd.adobe.aue.filter+json',
-      src: isLocal
+      src: orgSiteInPath
         ? `/${org}/${site}/component-filters.json`
         : '/component-filters.json',
     }),

--- a/src/ue/ue.js
+++ b/src/ue/ue.js
@@ -23,17 +23,16 @@ import rewriteIcons from './rewrite-icons.js';
 /**
  * Injects AEM HTML head entries into the head node of an HTML document.
  *
- * @param {Object} daCtx - The Dark Alley context object containing org, site,
- * and isLocal properties.
+ * @param {Object} daCtx - The Dark Alley context object containing org and site
  * @param {Object} headNode - The head node of the HTML document where AEM head entries
  * will be injected.
  * @param {string} headHtmlStr - The HTML string containing head entries from AEM.
  */
 function injectAEMHtmlHeadEntries(daCtx, headNode, headHtmlStr) {
-  const { org, site, isLocal } = daCtx;
+  const { org, site, orgSiteInPath } = daCtx;
   const aemHeadHtmlTree = fromHtml(headHtmlStr, { fragment: true });
 
-  if (isLocal) {
+  if (orgSiteInPath) {
     const headScriptsAndLinks = selectAll(
       'script[src], link[href]',
       aemHeadHtmlTree,

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -18,6 +18,7 @@ function getRefSiteOrgPath(hostname, pathname) {
       site,
       org,
       path: `/${parts.join('/')}`,
+      orgSiteInPath: true,
     };
   }
   const parts = hostname.split('.');
@@ -29,12 +30,13 @@ function getRefSiteOrgPath(hostname, pathname) {
         site: subdomainParts[1],
         org: subdomainParts[2],
         path: pathname,
+        orgSiteInPath: false,
       };
     }
   }
 
   return {
-    ref: undefined, site: undefined, org: undefined, path: pathname,
+    ref: undefined, site: undefined, org: undefined, path: pathname, orgSiteInPath: false,
   };
 }
 
@@ -48,7 +50,7 @@ export function getDaCtx(req) {
 
   // TODO this requires some improvements to be more robust
   const {
-    org, site, path, ref,
+    org, site, path, ref, orgSiteInPath,
   } = getRefSiteOrgPath(hostname, pathname);
 
   // Santitize the string
@@ -60,7 +62,7 @@ export function getDaCtx(req) {
 
   // Set base details
   const daCtx = {
-    path, org, site, ref, isLocal: hostname === 'localhost',
+    path, org, site, ref, isLocal: hostname.endsWith('localhost'), orgSiteInPath,
   };
 
   // Sanitize the remaining path parts

--- a/test/ue/scaffold.test.js
+++ b/test/ue/scaffold.test.js
@@ -125,7 +125,8 @@ describe('UE scaffold', () => {
     it('generates correct head entries for local environment', () => {
       daCtx.isLocal = true;
       daCtx.hostname = 'localhost';
-      
+      daCtx.orgSiteInPath = true;
+
       const entries = scaffold.getUEHtmlHeadEntries(daCtx, aemCtx);
 
       // Check meta tags
@@ -180,6 +181,58 @@ describe('UE scaffold', () => {
       assert.strictEqual(
         componentFiltersScript.properties.src,
         '/org/site/component-filters.json'
+      );
+    });
+
+    it('doesn\'t set paths in head if using a subdomain on localhost', () => {
+      daCtx.isLocal = true;
+      daCtx.hostname = 'main--site--org.da.localhost';
+      daCtx.orgSiteInPath = false;
+
+      const entries = scaffold.getUEHtmlHeadEntries(daCtx, aemCtx);
+      const metaTags = entries.filter((entry) => entry.tagName === 'meta');
+
+      // Check system:ab meta tag
+      const ueSystemTag = metaTags.find(
+        (tag) => tag.properties.name === 'urn:adobe:aue:system:ab'
+      );
+      assert.ok(ueSystemTag);
+      assert.strictEqual(
+        ueSystemTag.properties.content,
+        'da:https://test-ue-host/org/site/some-path'
+      );
+
+      const scriptTags = entries.filter((entry) => entry.tagName === 'script');
+
+      // Check component definition script
+      const componentDefScript = scriptTags.find(
+        (tag) =>
+          tag.properties.type === 'application/vnd.adobe.aue.component+json'
+      );
+      assert.ok(componentDefScript);
+      assert.strictEqual(
+        componentDefScript.properties.src,
+        '/component-definition.json'
+      );
+
+      // Check component models script
+      const componentModelsScript = scriptTags.find(
+        (tag) => tag.properties.type === 'application/vnd.adobe.aue.model+json'
+      );
+      assert.ok(componentModelsScript);
+      assert.strictEqual(
+        componentModelsScript.properties.src,
+        '/component-models.json'
+      );
+
+      // Check component filters script
+      const componentFiltersScript = scriptTags.find(
+        (tag) => tag.properties.type === 'application/vnd.adobe.aue.filter+json'
+      );
+      assert.ok(componentFiltersScript);
+      assert.strictEqual(
+        componentFiltersScript.properties.src,
+        '/component-filters.json'
       );
     });
   });


### PR DESCRIPTION
Allows using domains like https://main--da-ue-playground--hannessolo.ue.localhost:4712/demo 

- The meta tag written into the HTML is still `<meta name="urn:adobe:aue:system:ab" content="da:https://localhost:4712/hannessolo/da-ue-playground/demo">` - since using subdomains causes DNS issues outside of the browser, which maps `*.localhost` to `localhost` without a `/etc/hosts` entry
-  The links to component-models are fixed to remove the path:
```
<script type="application/vnd.adobe.aue.component+json" src="/component-definition.json"></script>
<script type="application/vnd.adobe.aue.model+json" src="/component-models.json"></script>
<script type="application/vnd.adobe.aue.filter+json" src="/component-filters.json"></script>
```