### PR TITLE
fix: sanitize JWT cookie value to prevent cookie injection

### DIFF
--- a/src/routes/cookie.js
+++ b/src/routes/cookie.js
@@ -55,7 +55,8 @@ export async function getCookie({ req, daCtx }) {
 
   const authToken = headers.get('Authorization');
   if (authToken) {
-    const cookieValue = authToken.split(' ')[1];
+    // Sanitize to JWT-safe chars (base64url + dot separator) to prevent cookie injection
+    const cookieValue = authToken.split(' ')[1]?.replace(/[^a-zA-Z0-9\-_.]/g, '') || null;
 
     if (cookieValue) {
       const { org, site } = daCtx;


### PR DESCRIPTION
Fixes a cookie injection vulnerability where the auth_token cookie value was set directly from the Authorization header without sanitization. An attacker could inject arbitrary cookie attributes (e.g., ; Domain=.evil.com) via a crafted header. The fix sanitizes the value to only allow valid JWT characters (base64url + dot separator).