### PR TITLE
fix: Unify CORS Response Headers

### DIFF
--- a/src/handlers/options.js
+++ b/src/handlers/options.js
@@ -11,7 +11,7 @@
  */
 
 import { daResp } from '../responses/index.js';
-import { DEFAULT_CORS_HEADERS, isTrustedOrigin } from '../utils/constants.js';
+import { isTrustedOrigin } from '../utils/constants.js';
 
 export default async function optionsHandler({ req }) {
   const { headers } = req;
@@ -23,13 +23,7 @@ export default async function optionsHandler({ req }) {
     && headers.get('Access-Control-Request-Method') !== null
     && headers.get('Access-Control-Request-Headers') !== null
   ) {
-    const respHeaders = { ...DEFAULT_CORS_HEADERS };
-    respHeaders['Access-Control-Allow-Origin'] = req.headers.get('Origin');
-
-    return new Response(null, {
-      status: 204,
-      headers: respHeaders,
-    });
+    return new Response(null, { status: 204 });
   } else {
     return new Response(null, {
       headers: {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { getDaCtx } from './utils/daCtx.js';
+import { isTrustedOrigin } from './utils/constants.js';
 
 import getHandler from './handlers/get.js';
 import { get404, getRobots } from './responses/index.js';
@@ -18,13 +19,32 @@ import postHandlers from './handlers/post.js';
 import unknownHandler from './handlers/unknown.js';
 import optionsHandler from './handlers/options.js';
 
+function withCorsHeaders(response, origin) {
+  const headers = new Headers(response.headers);
+  if (isTrustedOrigin(origin)) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Credentials', 'true');
+  } else {
+    headers.set('Access-Control-Allow-Origin', '*');
+    headers.delete('Access-Control-Allow-Credentials');
+  }
+  headers.set('Access-Control-Allow-Methods', 'GET, HEAD, POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, x-site-token');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export default {
   async fetch(req, env) {
     const url = new URL(req.url);
+    const origin = req.headers.get('Origin');
 
-    if (url.pathname === '/favicon.ico') return get404();
-    if (url.pathname === '/robots.txt') return getRobots();
-    if (url.pathname.startsWith('/.rum/')) return new Response(null, { status: 200 });
+    if (url.pathname === '/favicon.ico') return withCorsHeaders(get404(), origin);
+    if (url.pathname === '/robots.txt') return withCorsHeaders(getRobots(), origin);
+    if (url.pathname.startsWith('/.rum/')) return withCorsHeaders(new Response(null, { status: 200 }), origin);
 
     const daCtx = getDaCtx(req);
 
@@ -45,6 +65,6 @@ export default {
       default:
         resp = unknownHandler();
     }
-    return resp;
+    return withCorsHeaders(resp, origin);
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ import postHandlers from './handlers/post.js';
 import unknownHandler from './handlers/unknown.js';
 import optionsHandler from './handlers/options.js';
 
-function withCorsHeaders(response, origin) {
+function withCorsHeaders(response, req) {
+  const origin = req.headers.get('Origin');
   const headers = new Headers(response.headers);
   if (isTrustedOrigin(origin)) {
     headers.set('Access-Control-Allow-Origin', origin);
@@ -40,11 +41,10 @@ function withCorsHeaders(response, origin) {
 export default {
   async fetch(req, env) {
     const url = new URL(req.url);
-    const origin = req.headers.get('Origin');
 
-    if (url.pathname === '/favicon.ico') return withCorsHeaders(get404(), origin);
-    if (url.pathname === '/robots.txt') return withCorsHeaders(getRobots(), origin);
-    if (url.pathname.startsWith('/.rum/')) return withCorsHeaders(new Response(null, { status: 200 }), origin);
+    if (url.pathname === '/favicon.ico') return get404();
+    if (url.pathname === '/robots.txt') return getRobots();
+    if (url.pathname.startsWith('/.rum/')) return new Response(null, { status: 200 });
 
     const daCtx = getDaCtx(req);
 
@@ -65,6 +65,6 @@ export default {
       default:
         resp = unknownHandler();
     }
-    return withCorsHeaders(resp, origin);
+    return withCorsHeaders(resp, req);
   },
 };

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -15,7 +15,6 @@ export function daResp({
   body, status, contentType, contentLength,
 }) {
   const headers = new Headers();
-  headers.append('Access-Control-Allow-Origin', '*');
 
   if (contentType) {
     headers.append('Content-Type', contentType);

--- a/src/routes/aem-proxy.js
+++ b/src/routes/aem-proxy.js
@@ -91,6 +91,5 @@ export async function handleAEMProxyRequest({ req, env, daCtx }) {
     response = new Response(response.body, response);
   }
 
-  response.headers.set('Access-Control-Allow-Origin', '*');
   return response;
 }

--- a/src/routes/cookie.js
+++ b/src/routes/cookie.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { daResp, get401 } from '../responses/index.js';
-import { DEFAULT_CORS_HEADERS, isTrustedOrigin } from '../utils/constants.js';
+import { isTrustedOrigin } from '../utils/constants.js';
 
 async function exchangeSiteToken(org, site, accessToken) {
   try {
@@ -75,11 +75,6 @@ export async function getCookie({ req, daCtx }) {
           respHeaders.append('Set-Cookie', `site_token=${siteTokenData.siteToken}; Secure; Path=/; HttpOnly; SameSite=None; Partitioned; Max-Age=${maxAge}`);
         }
       }
-
-      respHeaders.append('Access-Control-Allow-Origin', req.headers.get('Origin'));
-      Object.entries(DEFAULT_CORS_HEADERS).forEach(([key, value]) => {
-        respHeaders.append(key, value);
-      });
 
       return new Response('cookie set', { headers: respHeaders });
     }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,12 +37,6 @@ export function isTrustedOrigin(origin) {
   return TRUSTED_ORIGINS_PATTERNS.some((pattern) => pattern.test(origin));
 }
 
-export const DEFAULT_CORS_HEADERS = {
-  'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Authorization, Content-Type, x-site-token',
-  'Access-Control-Allow-Credentials': 'true',
-};
-
 export const UNAUTHORIZED_HTML_MESSAGE = `
 <html>
 <head>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,14 +124,5 @@ describe('worker fetch handler', () => {
       assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Authorization, Content-Type, x-site-token');
     });
 
-    it('applies CORS to early-return paths (/.rum/)', async () => {
-      const req = new Request('https://main--site--org.ue.da.live/.rum/100', {
-        headers: { Origin: 'https://da.live' },
-      });
-      const res = await worker.fetch(req, {});
-
-      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'https://da.live');
-      assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), 'true');
-    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,28 +14,30 @@
 import assert from 'assert';
 import esmock from 'esmock';
 
+const HANDLER_MOCKS = {
+  '../src/handlers/get.js': {
+    default: async () => new Response('get-handled', { status: 200 }),
+  },
+  '../src/handlers/post.js': {
+    default: async () => new Response('post-handled', { status: 200 }),
+  },
+  '../src/handlers/options.js': {
+    default: async () => new Response('options-handled', { status: 204 }),
+  },
+  '../src/handlers/head.js': {
+    default: async () => new Response(null, { status: 200 }),
+  },
+  '../src/handlers/unknown.js': {
+    default: () => new Response('unknown', { status: 405 }),
+  },
+};
+
 describe('worker fetch handler', () => {
   describe('/.rum/ routing', () => {
     let worker;
 
     beforeEach(async () => {
-      worker = (await esmock('../src/index.js', {
-        '../src/handlers/get.js': {
-          default: async () => new Response('get-handled', { status: 200 }),
-        },
-        '../src/handlers/post.js': {
-          default: async () => new Response('post-handled', { status: 200 }),
-        },
-        '../src/handlers/options.js': {
-          default: async () => new Response('options-handled', { status: 204 }),
-        },
-        '../src/handlers/head.js': {
-          default: async () => new Response(null, { status: 200 }),
-        },
-        '../src/handlers/unknown.js': {
-          default: () => new Response('unknown', { status: 405 }),
-        },
-      })).default;
+      worker = (await esmock('../src/index.js', HANDLER_MOCKS)).default;
     });
 
     it('silently returns 200 for GET /.rum/100', async () => {
@@ -64,6 +66,72 @@ describe('worker fetch handler', () => {
 
       assert.ok(res instanceof Response, 'must return a Response');
       assert.strictEqual(res.status, 200);
+    });
+  });
+
+  describe('CORS headers', () => {
+    let worker;
+
+    beforeEach(async () => {
+      worker = (await esmock('../src/index.js', HANDLER_MOCKS)).default;
+    });
+
+    it('mirrors origin and sets credentials for a trusted origin', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/some/path', {
+        headers: { Origin: 'https://da.live' },
+      });
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'https://da.live');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), 'true');
+    });
+
+    it('returns wildcard and no credentials for an untrusted origin', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/some/path', {
+        headers: { Origin: 'https://evil.example.com' },
+      });
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), null);
+    });
+
+    it('returns wildcard and no credentials when no Origin header is present', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/some/path');
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), null);
+    });
+
+    it('sets Allow-Methods and Allow-Headers on trusted origin responses', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/some/path', {
+        headers: { Origin: 'https://da.live' },
+      });
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Methods'), 'GET, HEAD, POST, OPTIONS');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Authorization, Content-Type, x-site-token');
+    });
+
+    it('sets Allow-Methods and Allow-Headers on untrusted origin responses', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/some/path', {
+        headers: { Origin: 'https://untrusted.example.com' },
+      });
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Methods'), 'GET, HEAD, POST, OPTIONS');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Authorization, Content-Type, x-site-token');
+    });
+
+    it('applies CORS to early-return paths (/.rum/)', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/.rum/100', {
+        headers: { Origin: 'https://da.live' },
+      });
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'https://da.live');
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Credentials'), 'true');
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -123,6 +123,5 @@ describe('worker fetch handler', () => {
       assert.strictEqual(res.headers.get('Access-Control-Allow-Methods'), 'GET, HEAD, POST, OPTIONS');
       assert.strictEqual(res.headers.get('Access-Control-Allow-Headers'), 'Authorization, Content-Type, x-site-token');
     });
-
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Unify CORS header handling in responses:
1. Trusted Origins receive:
 1.1 `access-control-allow-origin: <caller_origin>` reflected
 1.2 `access-control-allow-credentials: true`
2. Everyone else
  2.1 `access-control-allow-origin: *`
  2.2  No `access-control-allow-credentials` -> can't send `fetch` requests with cookies

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. UE hosted in experience.adobe.com is switching to service workers and was getting inconsistent CORS responses, when trying to use the cookies.
2. The sprinkled CORS header handling was making it very difficult to troubleshoot CORS issues and slowed down development a lot in the past weeks, during hackathons.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Additionally, a security review from Claude to double check my thinking:

| Area | Before | After | Risk |
  |---|---|---|---|
  | AEM proxy — trusted origin | `*`, no credentials | Mirrored origin + credentials | Minor: extends trusted-origin XSS attack surface to proxy responses (pre-existing risk on OPTIONS/cookie) |
  | DA admin non-HTML GET + POST — trusted origin | No CORS headers | Mirrored origin + credentials | Intentional — trusted origins can now read these responses authenticated |
  | DA admin non-HTML GET + POST — untrusted origin | No CORS headers | `*`, no credentials | Untrusted callers can now read 401 error bodies cross-origin — not sensitive |
  | OPTIONS preflight — untrusted origin | 403 + `*` | 403 + `*` | No change |
  | Cookie endpoint (`/gimme_cookie`) | Mirrored origin + credentials | Mirrored origin + credentials | No change |
  | `Access-Control-Allow-Methods/Headers` on non-OPTIONS | Not present | Present | No impact — browsers ignore these on non-preflight responses |