### PR TITLE
fix: add nonce to quickedit for 404 cases

### DIFF
--- a/src/routes/aem-proxy.js
+++ b/src/routes/aem-proxy.js
@@ -14,12 +14,14 @@ import {
   applyQuickEditToScript,
   buildQuickEdit404Html,
   buildQuickEditCookie,
+  extractCspNonce,
   getQuickEditCookiePath,
   prepareQuickEditDocument,
 } from '../utils/quick-edit.js';
 
 function buildQuickEditDocumentResponse(html, response) {
-  const { html: modifiedHtml, entryPath } = prepareQuickEditDocument(html);
+  const nonce = extractCspNonce(response.headers.get('Content-Security-Policy'));
+  const { html: finalHtml, entryPath } = prepareQuickEditDocument(html, nonce);
   const headers = new Headers(response.headers);
   // Body has been decoded to text; drop headers that describe the encoded form.
   headers.delete('Content-Encoding');
@@ -31,10 +33,10 @@ function buildQuickEditDocumentResponse(html, response) {
   } else {
     console.log('[quick-edit] doc load: no <script src="…/scripts.js"> found in html');
   }
-  if (modifiedHtml !== html) {
-    console.log('[quick-edit] doc load: import map injected into HTML');
+  if (nonce) {
+    console.log('[quick-edit] doc load: CSP nonce applied to script tags');
   }
-  return new Response(modifiedHtml, {
+  return new Response(finalHtml, {
     status: response.status,
     statusText: response.statusText,
     headers,
@@ -89,7 +91,7 @@ export async function handleAEMProxyRequest({ req, env, daCtx }) {
       console.log('[quick-edit] doc load: head.html not found on origin');
     }
     const headHtml = fixUrlsWhenLocalDev(rawHead || '', daCtx);
-    response = buildQuickEditDocumentResponse(buildQuickEdit404Html(headHtml), response);
+    response = buildQuickEditDocumentResponse(buildQuickEdit404Html(headHtml, response), response);
   } else if (isQuickEditDoc && isHtml && response.ok) {
     const html = await response.text();
     response = buildQuickEditDocumentResponse(html, response);

--- a/src/utils/quick-edit.js
+++ b/src/utils/quick-edit.js
@@ -10,6 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+import { fromHtml } from 'hast-util-from-html';
+import { toHtml } from 'hast-util-to-html';
+import { select, selectAll } from 'hast-util-select';
+
+import { h } from 'hastscript';
+
 import { DEFAULT_HTML_TEMPLATE } from './constants.js';
 
 const QUICK_EDIT_IMPORT_MAP = {
@@ -18,8 +24,6 @@ const QUICK_EDIT_IMPORT_MAP = {
     'da-y-wrapper': 'https://da.live/deps/da-y-wrapper/dist/index.js',
   },
 };
-
-const IMPORT_MAP_SCRIPT_RE = /<script\b([^>]*\btype\s*=\s*["']importmap["'][^>]*)>\s*([^<]*)\s*<\/script>/is;
 
 // Appended to the bottom of the project's scripts/scripts.js. Because it runs
 // inside that module, `loadPage` is already in scope (no import needed) and the
@@ -48,15 +52,6 @@ const QUICK_EDIT_BOOTSTRAP = `
 
 export const QUICK_EDIT_COOKIE = 'da-quick-edit';
 
-/**
- * Build the minimal page scaffold for quick-edit when the upstream document 404s.
- * @param {string} [headHtml] Resolved AEM head.html fragment
- * @returns {string}
- */
-export function buildQuickEdit404Html(headHtml = '') {
-  return `<html><head>${headHtml}</head>${DEFAULT_HTML_TEMPLATE}</html>`;
-}
-
 /** @param {object} map */
 function quickEditSatisfied(map) {
   const imports = map?.imports;
@@ -78,91 +73,120 @@ function mergeImportMaps(existing, overlay) {
   };
 }
 
-/** @param {string} attrs Opening-tag attributes (includes type="importmap"). */
-function importMapScriptTag(attrs, map) {
-  const body = JSON.stringify(map);
-  return attrs.trim()
-    ? `<script ${attrs.trim()}>${body}</script>`
-    : `<script type="importmap">${body}</script>`;
-}
-
-/** Insert snippet at the start of `<head>`, or before `</head>`, or prepend. */
-function insertInHead(html, snippet) {
-  const headOpen = html.match(/<head[^>]*>/i);
-  if (headOpen) {
-    const at = headOpen.index + headOpen[0].length;
-    return html.slice(0, at) + snippet + html.slice(at);
-  }
-  const headClose = html.match(/<\/head>/i);
-  if (headClose) {
-    return html.slice(0, headClose.index) + snippet + headClose[0]
-      + html.slice(headClose.index + headClose[0].length);
-  }
-  return snippet + html;
-}
+// ─── hast tree helpers ────────────────────────────────────────────────────────
 
 /**
- * Inject or update the quick-edit import map in the document `<head>`.
- * Replaces an existing import map in place (preserving attributes such as
- * `nonce`). No-ops when the map already includes the quick-edit entries.
- * @param {string} html
- * @returns {string}
+ * Walk the tree and return the pathname of the first `<script src="…/scripts.js">`.
+ * @param {import('hast').Root} tree
+ * @returns {string | undefined}
  */
-export function injectImportMap(html) {
-  const existing = html.match(IMPORT_MAP_SCRIPT_RE);
-
-  if (existing) {
-    let parsed;
+function findEntryScriptInTree(tree) {
+  for (const node of selectAll('script[src]', tree)) {
     try {
-      parsed = JSON.parse(existing[2]);
-    } catch {
-      parsed = {};
-    }
-    if (quickEditSatisfied(parsed)) return html;
-
-    const merged = mergeImportMaps(parsed, QUICK_EDIT_IMPORT_MAP);
-    const tag = importMapScriptTag(existing[1], merged);
-    return html.replace(existing[0], tag);
-  }
-
-  const tag = importMapScriptTag('', QUICK_EDIT_IMPORT_MAP);
-  return insertInHead(html, tag);
-}
-
-/**
- * Find the project's entry script path in an HTML document. Looks for a
- * `<script src="…/scripts.js">` tag and returns its normalized pathname, so it
- * works regardless of subfolder (`/foo/bar/scripts.js`) and ignores an
- * unrelated file that merely ends in something else.
- * @param {string} html The page HTML
- * @returns {string | undefined} The entry script pathname (e.g. `/scripts/scripts.js`)
- */
-export function findEntryScriptPath(html) {
-  const tagRegex = /<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
-  let match = tagRegex.exec(html);
-  while (match !== null) {
-    let pathname;
-    try {
-      pathname = new URL(match[1], 'https://da.local').pathname;
-    } catch {
-      pathname = undefined;
-    }
-    if (pathname && /\/scripts\.js$/.test(pathname)) return pathname;
-    match = tagRegex.exec(html);
+      const { pathname } = new URL(String(node.properties.src), 'https://da.local');
+      if (/\/scripts\.js$/.test(pathname)) return pathname;
+    } catch { /* ignore */ }
   }
   return undefined;
 }
 
 /**
- * Apply quick-edit document transforms: discover entry script, inject import map.
+ * Inject or update the quick-edit import map in the tree.
+ * Returns true when the tree was modified, false when already satisfied.
+ * @param {import('hast').Root} tree
+ * @returns {boolean}
+ */
+function injectImportMap(tree) {
+  const existing = select('script[type="importmap"]', tree);
+  if (existing) {
+    const text = (existing.children ?? []).find((c) => c.type === 'text')?.value ?? '';
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = {};
+    }
+    if (quickEditSatisfied(parsed)) return false;
+    const merged = mergeImportMaps(parsed, QUICK_EDIT_IMPORT_MAP);
+    existing.children = [{ type: 'text', value: JSON.stringify(merged) }];
+    return true;
+  }
+  const node = h('script', { type: 'importmap' }, JSON.stringify(QUICK_EDIT_IMPORT_MAP));
+  const head = select('head', tree);
+  if (head) {
+    head.children.unshift(node);
+  } else {
+    tree.children = [node, ...(tree.children ?? [])];
+  }
+  return true;
+}
+
+/**
+ * Add the CSP nonce attribute to every `<script>` element that lacks one.
+ * @param {import('hast').Root} tree
+ * @param {string | undefined} nonce
+ */
+function applyNonceInTree(tree, nonce) {
+  if (!nonce) return;
+  for (const node of selectAll('script', tree)) {
+    node.properties ??= {};
+    node.properties.nonce = nonce;
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Extract the CSP nonce value from a Content-Security-Policy header.
+ * Matches the `'nonce-VALUE'` token in the script-src directive only.
+ * @param {string | null} cspHeader
+ * @returns {string | undefined}
+ */
+export function extractCspNonce(cspHeader) {
+  if (!cspHeader) return undefined;
+  const directive = cspHeader.match(/(?:^|;)\s*script-src\s+([^;]*)/i);
+  if (!directive) return undefined;
+  const nonce = directive[1].match(/'nonce-([^']+)'/);
+  return nonce ? nonce[1] : undefined;
+}
+
+/**
+ * Build the minimal page scaffold for quick-edit when the upstream document 404s.
+ * Extracts the CSP nonce from the response and applies it to all script tags.
+ * @param {string} [headHtml] Resolved AEM head.html fragment
+ * @param {Response} [response] Upstream response — used to read the CSP header
+ * @returns {string}
+ */
+export function buildQuickEdit404Html(headHtml = '', response = undefined) {
+  const nonce = extractCspNonce(response?.headers?.get('Content-Security-Policy'));
+  const tree = fromHtml(`<html><head>${headHtml}</head>${DEFAULT_HTML_TEMPLATE}</html>`);
+  injectImportMap(tree);
+  applyNonceInTree(tree, nonce);
+  return toHtml(tree, { allowDangerousHtml: true });
+}
+
+/**
+ * Find the project's entry script path in an HTML document. Looks for a
+ * `<script src="…/scripts.js">` tag and returns its normalized pathname.
+ * @param {string} html The page HTML
+ * @returns {string | undefined}
+ */
+export function findEntryScriptPath(html) {
+  return findEntryScriptInTree(fromHtml(html, { fragment: true }));
+}
+
+/**
+ * Apply quick-edit document transforms: discover entry script, inject import map, apply nonce.
  * @param {string} html
+ * @param {string | undefined} [nonce] CSP nonce to stamp onto all script tags
  * @returns {{ html: string, entryPath: string | undefined }}
  */
-export function prepareQuickEditDocument(html) {
-  return {
-    html: injectImportMap(html),
-    entryPath: findEntryScriptPath(html),
-  };
+export function prepareQuickEditDocument(html, nonce) {
+  const tree = fromHtml(html);
+  const entryPath = findEntryScriptInTree(tree);
+  injectImportMap(tree);
+  applyNonceInTree(tree, nonce);
+  return { html: toHtml(tree, { allowDangerousHtml: true }), entryPath };
 }
 
 /**

--- a/test/utils/quick-edit.test.js
+++ b/test/utils/quick-edit.test.js
@@ -28,42 +28,43 @@ loadPage();
 `;
 
 describe('quick-edit script transform', () => {
-  describe('injectImportMap', () => {
+  describe('prepareQuickEditDocument', () => {
     const countImportMaps = (html) => (html.match(/type\s*=\s*["']importmap["']/gi) || []).length;
 
-    it('injects import map at the start of head', () => {
-      const html = '<html><head><title>Test</title></head><body>Content</body></html>';
-      const out = quickEdit.injectImportMap(html);
+    it('injects import map at the start of head and finds entry script', () => {
+      const html = '<html><head><script src="/scripts/scripts.js" type="module"></script></head><body></body></html>';
+      const { html: out, entryPath } = quickEdit.prepareQuickEditDocument(html);
+      assert.strictEqual(entryPath, '/scripts/scripts.js');
       assert.ok(out.includes('<head><script type="importmap">'));
       assert.ok(out.includes('"da-lit"'));
     });
 
-    it('injects before module scripts in head', () => {
+    it('injects import map before module scripts in head', () => {
       const html = '<html><head><script src="/scripts/scripts.js" type="module"></script></head></html>';
-      const out = quickEdit.injectImportMap(html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
       const mapPos = out.indexOf('importmap');
       const scriptPos = out.indexOf('scripts.js');
       assert.ok(mapPos < scriptPos, 'import map should precede entry module script');
     });
 
-    it('prepends import map if no head tag', () => {
+    it('inserts import map into implicit head when source has no head tag', () => {
       const html = '<html><body>Content</body></html>';
-      const out = quickEdit.injectImportMap(html);
-      assert.ok(out.startsWith('<script type="importmap">'));
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
+      assert.ok(out.includes('<head><script type="importmap">'));
     });
 
-    it('merges in place and keeps a single import map', () => {
+    it('merges import map in place and keeps a single import map', () => {
       const existingMap = {
         imports: { 'existing-package': 'https://example.com/existing.js' },
       };
       const html = `<html><head><script type="importmap">${JSON.stringify(existingMap)}</script></head><body></body></html>`;
-      const out = quickEdit.injectImportMap(html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
       assert.strictEqual(countImportMaps(out), 1);
       assert.ok(out.includes('"existing-package"'));
       assert.ok(out.includes('"da-y-wrapper"'));
     });
 
-    it('merges and overwrites with quick-edit imports', () => {
+    it('merges and overwrites existing import map with quick-edit imports', () => {
       const existingMap = {
         imports: {
           'da-lit': 'https://old.com/lit.js',
@@ -71,26 +72,26 @@ describe('quick-edit script transform', () => {
         },
       };
       const html = `<html><head><script type="importmap">${JSON.stringify(existingMap)}</script></head></html>`;
-      const out = quickEdit.injectImportMap(html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
       assert.strictEqual(countImportMaps(out), 1);
       assert.ok(out.includes('"da-lit":"https://da.live/deps/lit/dist/index.js"'));
       assert.ok(out.includes('"other":"https://other.com/other.js"'));
     });
 
-    it('preserves nonce and scopes on merge', () => {
+    it('preserves nonce and scopes on import map merge', () => {
       const existingMap = {
         imports: { 'da-parser': '/deps/da-parser/dist/index.js' },
         scopes: { '/blocks/': { 'local-dep': './dep.js' } },
       };
       const html = `<html><head><script nonce="aem" type="importmap">${JSON.stringify(existingMap)}</script></head></html>`;
-      const out = quickEdit.injectImportMap(html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
       assert.ok(out.includes('nonce="aem"'));
       assert.ok(out.includes('"scopes"'));
       assert.ok(out.includes('"da-parser"'));
       assert.ok(out.includes('"da-y-wrapper"'));
     });
 
-    it('is idempotent when quick-edit entries are already present', () => {
+    it('does not duplicate import map entries when quick-edit entries are already present', () => {
       const map = {
         imports: {
           'da-lit': 'https://da.live/deps/lit/dist/index.js',
@@ -98,25 +99,24 @@ describe('quick-edit script transform', () => {
         },
       };
       const html = `<html><head><script type="importmap">${JSON.stringify(map)}</script></head></html>`;
-      assert.strictEqual(quickEdit.injectImportMap(html), html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
+      assert.strictEqual(countImportMaps(out), 1);
+      assert.ok(out.includes('"da-lit"'));
+      assert.ok(out.includes('"da-y-wrapper"'));
     });
 
     it('replaces invalid existing import map in place', () => {
       const html = '<html><head><script nonce="x" type="importmap">invalid json</script></head></html>';
-      const out = quickEdit.injectImportMap(html);
+      const { html: out } = quickEdit.prepareQuickEditDocument(html);
       assert.strictEqual(countImportMaps(out), 1);
       assert.ok(out.includes('nonce="x"'));
       assert.ok(out.includes('"da-lit"'));
     });
-  });
 
-  describe('prepareQuickEditDocument', () => {
-    it('injects import map and finds entry script', () => {
+    it('applies CSP nonce to all script tags', () => {
       const html = '<html><head><script src="/scripts/scripts.js" type="module"></script></head><body></body></html>';
-      const { html: out, entryPath } = quickEdit.prepareQuickEditDocument(html);
-      assert.strictEqual(entryPath, '/scripts/scripts.js');
-      assert.ok(out.includes('importmap'));
-      assert.ok(out.includes('"da-lit"'));
+      const { html: out } = quickEdit.prepareQuickEditDocument(html, 'abc123');
+      assert.ok(out.includes('nonce="abc123"'));
     });
   });
 


### PR DESCRIPTION
## Description

This pull request introduces three changes:

- It adds the nonce to the import map, as this is needed and was not there before
- It takes the nonce from the original request and replaces all the script tags with the correct nonce, because the one from head.html proxied from AEM does not match
- It changes the implementation to use HAST utils to improve the parsing and have way less regex checks.

```
<head>
        <script type="importmap" nonce="YgWo8SHleW+da7pbwCQry6lv">
            {
                "imports": {
                    "da-lit": "https://da.live/deps/lit/dist/index.js",
                    "da-y-wrapper": "https://da.live/deps/da-y-wrapper/dist/index.js"
                }
            }</script>
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <script nonce="YgWo8SHleW+da7pbwCQry6lv" src="/scripts/aem.js" type="module"></script>
        <script nonce="YgWo8SHleW+da7pbwCQry6lv" src="/scripts/scripts.js" type="module"></script>
        <link rel="stylesheet" href="/styles/styles.css">
    </head>
```
