### PR TITLE
feat: implement full HEAD request handling

### DIFF
--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -43,11 +43,12 @@ export default async function headHandler({ req, env, daCtx }) {
 
     if (daSourceHeadRes.status === 'fulfilled' && daSourceHeadRes.value.status === 200) {
       return daSourceHeadRes.value;
-    } else if (aemHeadRes.status === 'fulfilled') {
-      return aemHeadRes.value;
-    } else {
-      return get404();
     }
+    const aemResponse = aemHeadRes.status === 'fulfilled' ? aemHeadRes.value : null;
+    if (aemResponse && aemResponse.status < 500) {
+      return aemResponse;
+    }
+    return get404();
   }
 
   const url = new URL(req.url);

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { get404, getRobots } from '../responses/index.js';
+import { getRobots, head404 } from '../responses/index.js';
 import { handleAEMProxyRequest } from '../routes/aem-proxy.js';
 import { daSourceHead } from '../routes/da-admin.js';
 
@@ -25,8 +25,8 @@ async function aemHead({ req, env, daCtx }) {
 export default async function headHandler({ req, env, daCtx }) {
   const { path } = daCtx;
 
-  if (!daCtx.site) return get404();
-  if (path.startsWith('/favicon.ico')) return get404();
+  if (!daCtx.site) return head404();
+  if (path.startsWith('/favicon.ico')) return head404();
   if (path.startsWith('/robots.txt')) return getRobots();
 
   const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
@@ -48,7 +48,7 @@ export default async function headHandler({ req, env, daCtx }) {
     if (aemResponse && aemResponse.status < 500) {
       return aemResponse;
     }
-    return get404();
+    return head404();
   }
 
   const url = new URL(req.url);

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -14,6 +14,8 @@ import { get404, getRobots } from '../responses/index.js';
 import { handleAEMProxyRequest } from '../routes/aem-proxy.js';
 import { daSourceHead } from '../routes/da-admin.js';
 
+// for AEM we reuse the handleAEMProxyRequest for now as GETs are cheap here
+// TODO refine and review for later for a full HEAD requests on AEM
 async function aemHead({ req, env, daCtx }) {
   const getReq = new Request(req, { method: 'GET' });
   const resp = await handleAEMProxyRequest({ req: getReq, env, daCtx });

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -27,13 +27,8 @@ export default async function headHandler({ req, env, daCtx }) {
   if (path.startsWith('/favicon.ico')) return get404();
   if (path.startsWith('/robots.txt')) return getRobots();
 
-  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
-  if (resourceRegex.test(path)) {
-    return aemHead({ req, env, daCtx });
-  }
-
-  const assetRegex = /\.(png|jpg|jpeg|webp|gif|svg|ico)$/i;
-  if (assetRegex.test(path)) {
+  const aemRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html|png|jpg|jpeg|webp|gif|svg|ico)$/i;
+  if (aemRegex.test(path)) {
     return aemHead({ req, env, daCtx });
   }
 

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -27,8 +27,13 @@ export default async function headHandler({ req, env, daCtx }) {
   if (path.startsWith('/favicon.ico')) return get404();
   if (path.startsWith('/robots.txt')) return getRobots();
 
-  const aemRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html|png|jpg|jpeg|webp|gif|svg|ico)$/i;
-  if (aemRegex.test(path)) {
+  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
+  if (resourceRegex.test(path)) {
+    return aemHead({ req, env, daCtx });
+  }
+
+  const assetRegex = /\.(png|jpg|jpeg|webp|gif|svg|ico)$/i;
+  if (assetRegex.test(path)) {
     return aemHead({ req, env, daCtx });
   }
 

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -34,7 +34,18 @@ export default async function headHandler({ req, env, daCtx }) {
 
   const assetRegex = /\.(png|jpg|jpeg|webp|gif|svg|ico)$/i;
   if (assetRegex.test(path)) {
-    return aemHead({ req, env, daCtx });
+    const [daSourceHeadRes, aemHeadRes] = await Promise.allSettled([
+      daSourceHead({ env, daCtx }),
+      aemHead({ req, env, daCtx }),
+    ]);
+
+    if (daSourceHeadRes.status === 'fulfilled' && daSourceHeadRes.value.status === 200) {
+      return daSourceHeadRes.value;
+    } else if (aemHeadRes.status === 'fulfilled') {
+      return aemHeadRes.value;
+    } else {
+      return get404();
+    }
   }
 
   const url = new URL(req.url);

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -11,12 +11,42 @@
  */
 
 import { get404, getRobots } from '../responses/index.js';
+import { handleAEMProxyRequest } from '../routes/aem-proxy.js';
+import { daSourceHead } from '../routes/da-admin.js';
 
-// eslint-disable-next-line no-unused-vars
-export default async function headHandler({ env, daCtx }) {
+async function aemHead({ req, env, daCtx }) {
+  const getReq = new Request(req, { method: 'GET' });
+  const resp = await handleAEMProxyRequest({ req: getReq, env, daCtx });
+  return new Response(null, { status: resp.status, headers: resp.headers });
+}
+
+export default async function headHandler({ req, env, daCtx }) {
   const { path } = daCtx;
 
+  if (!daCtx.site) return get404();
   if (path.startsWith('/favicon.ico')) return get404();
   if (path.startsWith('/robots.txt')) return getRobots();
-  return undefined;
+
+  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
+  if (resourceRegex.test(path)) {
+    return aemHead({ req, env, daCtx });
+  }
+
+  const assetRegex = /\.(png|jpg|jpeg|webp|gif|svg|ico)$/i;
+  if (assetRegex.test(path)) {
+    return aemHead({ req, env, daCtx });
+  }
+
+  const url = new URL(req.url);
+  const isPreviewHost = url.hostname.endsWith('.preview.da.live') || url.hostname.endsWith('.stage-preview.da.live');
+
+  if (
+    url.searchParams.get('dapreview') === 'on'
+    || isPreviewHost
+    || url.searchParams.has('quick-edit')
+  ) {
+    return aemHead({ req, env, daCtx });
+  }
+
+  return daSourceHead({ env, daCtx });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default {
         resp = await optionsHandler({ req });
         break;
       case 'HEAD':
-        resp = await headHandler({ env, daCtx });
+        resp = await headHandler({ req, env, daCtx });
         break;
       case 'GET':
         resp = await getHandler({ req, env, daCtx });

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -36,6 +36,10 @@ export function get401(message = DEFAULT_UNAUTHORIZED_HTML_MESSAGE) {
   return daResp({ body: message, status: 401, contentType: 'text/html' });
 }
 
+export function head401() {
+  return new Response(null, { status: 401 });
+}
+
 export function getRobots() {
   const body = `User-agent: *
 Disallow: /`;

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -40,6 +40,10 @@ export function head401() {
   return new Response(null, { status: 401 });
 }
 
+export function head404() {
+  return new Response(null, { status: 404 });
+}
+
 export function getRobots() {
   const body = `User-agent: *
 Disallow: /`;

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -17,7 +17,9 @@ import putHelper from '../helpers/source.js';
 import { removeUEAttributes, unwrapParagraphs } from '../ue/attributes.js';
 import { prepareHtml } from '../ue/ue.js';
 import { getAemCtx, getAEMHtml } from '../utils/aemCtx.js';
-import { daResp, get401, get404, head401 } from '../responses/index.js';
+import {
+  daResp, get401, get404, head401,
+} from '../responses/index.js';
 import { BRANCH_NOT_FOUND_HTML_MESSAGE, DEFAULT_HTML_TEMPLATE, UNAUTHORIZED_HTML_MESSAGE } from '../utils/constants.js';
 import { getSiteConfig } from '../storage/config.js';
 import { restoreAbsoluteImages } from '../ue/rewrite-images.js';

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -130,6 +130,26 @@ export async function daSourceGet({ req, env, daCtx }) {
   });
 }
 
+export async function daSourceHead({ env, daCtx }) {
+  const {
+    org, site, path, ext, authToken,
+  } = daCtx;
+
+  if (!authToken) {
+    return get401();
+  }
+
+  const headers = new Headers();
+  headers.set('Authorization', authToken);
+
+  const adminPath = ext !== 'html' ? path : `${path}.${ext}`;
+  const adminUrl = new URL(`/source/${org}/${site}${adminPath}`, env.DA_ADMIN);
+  console.log(`-> HEAD ${adminUrl.toString()}`);
+  const response = await env.daadmin.fetch(adminUrl, { method: 'HEAD', headers });
+  console.log(`<- HEAD ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+  return new Response(null, { status: response.status, headers: response.headers });
+}
+
 export async function daSourcePost({ req, env, daCtx }) {
   const {
     org, site, path, ext, authToken,

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -17,7 +17,7 @@ import putHelper from '../helpers/source.js';
 import { removeUEAttributes, unwrapParagraphs } from '../ue/attributes.js';
 import { prepareHtml } from '../ue/ue.js';
 import { getAemCtx, getAEMHtml } from '../utils/aemCtx.js';
-import { daResp, get401, get404 } from '../responses/index.js';
+import { daResp, get401, get404, head401 } from '../responses/index.js';
 import { BRANCH_NOT_FOUND_HTML_MESSAGE, DEFAULT_HTML_TEMPLATE, UNAUTHORIZED_HTML_MESSAGE } from '../utils/constants.js';
 import { getSiteConfig } from '../storage/config.js';
 import { restoreAbsoluteImages } from '../ue/rewrite-images.js';
@@ -136,7 +136,7 @@ export async function daSourceHead({ env, daCtx }) {
   } = daCtx;
 
   if (!authToken) {
-    return get401();
+    return head401();
   }
 
   const headers = new Headers();

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -181,6 +181,81 @@ describe('HEAD handler', () => {
       });
     });
 
+    describe('when AEM proxy returns 401', () => {
+      let headHandler;
+
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response(null, { status: 401 }),
+          },
+        })).default;
+      });
+
+      it('passes through 401 so client can authenticate', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 401);
+      });
+    });
+
+    describe('when AEM proxy returns 403', () => {
+      let headHandler;
+
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response(null, { status: 403 }),
+          },
+        })).default;
+      });
+
+      it('passes through 403 so client knows access is denied', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 403);
+      });
+    });
+
+    describe('when AEM proxy returns 5xx', () => {
+      let headHandler;
+
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response(null, { status: 500 }),
+          },
+        })).default;
+      });
+
+      it('returns 404 when AEM has a server error', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 404);
+      });
+    });
+
     describe('when both daSourceHead and AEM proxy fail', () => {
       let headHandler;
 

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import esmock from 'esmock';
+import reqs from '../mocks/req.js';
+
+const { getDaCtx } = await import('../../src/utils/daCtx.js');
+
+describe('HEAD handler', () => {
+  describe('early returns', () => {
+    let headHandler;
+
+    beforeEach(async () => {
+      headHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': { daSourceHead: async () => new Response(null, { status: 200 }) },
+        '../../src/routes/aem-proxy.js': { handleAEMProxyRequest: async () => new Response(null, { status: 200 }) },
+      })).default;
+    });
+
+    it('returns 404 when site is missing', async () => {
+      const daCtx = getDaCtx(reqs.invalid);
+      const env = {};
+
+      const res = await headHandler({ req: reqs.invalid, env, daCtx });
+
+      assert.strictEqual(res.status, 404);
+    });
+
+    it('returns 404 for /favicon.ico', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/favicon.ico', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 404);
+    });
+
+    it('returns 200 for /robots.txt', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/robots.txt', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+    });
+  });
+
+  describe('resource extensions', () => {
+    let headHandler;
+    let aemProxyCallCount;
+
+    beforeEach(async () => {
+      aemProxyCallCount = 0;
+      headHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': { daSourceHead: async () => new Response(null, { status: 200 }) },
+        '../../src/routes/aem-proxy.js': {
+          handleAEMProxyRequest: async () => {
+            aemProxyCallCount += 1;
+            return new Response('proxied', { status: 200, headers: { 'Content-Type': 'text/css' } });
+          },
+        },
+      })).default;
+    });
+
+    it('proxies to AEM for .css and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/style.css', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+      assert.strictEqual(aemProxyCallCount, 1);
+    });
+
+    it('proxies to AEM for .js and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/script.js', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+      assert.strictEqual(aemProxyCallCount, 1);
+    });
+
+    it('proxies to AEM for .json and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/folder/content.json', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+      assert.strictEqual(aemProxyCallCount, 1);
+    });
+  });
+
+  describe('assets', () => {
+    let headHandler;
+
+    beforeEach(async () => {
+      headHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': { daSourceHead: async () => new Response(null, { status: 200 }) },
+        '../../src/routes/aem-proxy.js': {
+          handleAEMProxyRequest: async () => new Response('image-data', {
+            status: 200,
+            headers: { 'Content-Type': 'image/png', 'Content-Length': '42' },
+          }),
+        },
+      })).default;
+    });
+
+    it('proxies to AEM for .png and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('proxies to AEM for .svg and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/icon.svg', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('forwards headers from AEM proxy response', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.headers.get('Content-Type'), 'image/png');
+      assert.strictEqual(res.headers.get('Content-Length'), '42');
+    });
+  });
+
+  describe('preview', () => {
+    let headHandler;
+
+    beforeEach(async () => {
+      headHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': { daSourceHead: async () => new Response(null, { status: 200 }) },
+        '../../src/routes/aem-proxy.js': {
+          handleAEMProxyRequest: async () => new Response('preview', { status: 200 }),
+        },
+      })).default;
+    });
+
+    it('proxies to AEM when dapreview=on and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/folder/content?dapreview=on', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('proxies to AEM for preview host and returns no body', async () => {
+      const req = new Request('https://main--site--org.preview.da.live/folder/content', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('proxies to AEM when quick-edit param is present and returns no body', async () => {
+      const req = new Request('https://main--site--org.ue.da.live/folder/content?quick-edit', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+  });
+
+  describe('default content (DA source)', () => {
+    let headHandler;
+
+    beforeEach(async () => {
+      headHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': {
+          daSourceHead: async () => new Response(null, {
+            status: 200,
+            headers: { 'Content-Type': 'text/html', 'Content-Length': '1234' },
+          }),
+        },
+        '../../src/routes/aem-proxy.js': { handleAEMProxyRequest: async () => new Response() },
+      })).default;
+    });
+
+    it('calls daSourceHead for content path and returns no body', async () => {
+      const daCtx = getDaCtx(reqs.content);
+      const env = {};
+
+      const res = await headHandler({ req: reqs.content, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('forwards headers from daSourceHead', async () => {
+      const daCtx = getDaCtx(reqs.content);
+      const env = {};
+
+      const res = await headHandler({ req: reqs.content, env, daCtx });
+
+      assert.strictEqual(res.headers.get('Content-Type'), 'text/html');
+      assert.strictEqual(res.headers.get('Content-Length'), '1234');
+    });
+
+    it('forwards 404 from daSourceHead when content is not found', async () => {
+      const notFoundHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': {
+          daSourceHead: async () => new Response(null, { status: 404 }),
+        },
+        '../../src/routes/aem-proxy.js': { handleAEMProxyRequest: async () => new Response() },
+      })).default;
+
+      const daCtx = getDaCtx(reqs.content);
+      const env = {};
+
+      const res = await notFoundHandler({ req: reqs.content, env, daCtx });
+
+      assert.strictEqual(res.status, 404);
+    });
+
+    it('forwards 401 from daSourceHead when not authenticated', async () => {
+      const unauthHandler = (await esmock('../../src/handlers/head.js', {
+        '../../src/routes/da-admin.js': {
+          daSourceHead: async () => new Response(null, { status: 401 }),
+        },
+        '../../src/routes/aem-proxy.js': { handleAEMProxyRequest: async () => new Response() },
+      })).default;
+
+      const daCtx = getDaCtx(reqs.content);
+      const env = {};
+
+      const res = await unauthHandler({ req: reqs.content, env, daCtx });
+
+      assert.strictEqual(res.status, 401);
+    });
+  });
+});

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -113,51 +113,97 @@ describe('HEAD handler', () => {
   });
 
   describe('assets', () => {
-    let headHandler;
+    describe('when daSourceHead returns 200', () => {
+      let headHandler;
 
-    beforeEach(async () => {
-      headHandler = (await esmock('../../src/handlers/head.js', {
-        '../../src/routes/da-admin.js': { daSourceHead: async () => new Response(null, { status: 200 }) },
-        '../../src/routes/aem-proxy.js': {
-          handleAEMProxyRequest: async () => new Response('image-data', {
-            status: 200,
-            headers: { 'Content-Type': 'image/png', 'Content-Length': '42' },
-          }),
-        },
-      })).default;
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, {
+              status: 200,
+              headers: { 'Content-Type': 'image/png', 'Content-Length': '42' },
+            }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response(null, { status: 404 }),
+          },
+        })).default;
+      });
+
+      it('returns DA response for .png', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(await res.text(), '');
+        assert.strictEqual(res.headers.get('Content-Type'), 'image/png');
+        assert.strictEqual(res.headers.get('Content-Length'), '42');
+      });
+
+      it('returns DA response for .svg', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/icon.svg', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(await res.text(), '');
+      });
     });
 
-    it('proxies to AEM for .png and returns no body', async () => {
-      const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
-      const daCtx = getDaCtx(req);
-      const env = {};
+    describe('when daSourceHead fails and AEM proxy succeeds', () => {
+      let headHandler;
 
-      const res = await headHandler({ req, env, daCtx });
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response(null, { status: 200 }),
+          },
+        })).default;
+      });
 
-      assert.strictEqual(res.status, 200);
-      assert.strictEqual(await res.text(), '');
+      it('falls back to AEM response', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await headHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 200);
+        assert.strictEqual(await res.text(), '');
+      });
     });
 
-    it('proxies to AEM for .svg and returns no body', async () => {
-      const req = new Request('https://main--site--org.ue.da.live/icon.svg', { method: 'HEAD' });
-      const daCtx = getDaCtx(req);
-      const env = {};
+    describe('when both daSourceHead and AEM proxy fail', () => {
+      let headHandler;
 
-      const res = await headHandler({ req, env, daCtx });
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => Promise.reject(new Error('fail')),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => Promise.reject(new Error('fail')),
+          },
+        })).default;
+      });
 
-      assert.strictEqual(res.status, 200);
-      assert.strictEqual(await res.text(), '');
-    });
+      it('returns 404', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+        const daCtx = getDaCtx(req);
+        const env = {};
 
-    it('forwards headers from AEM proxy response', async () => {
-      const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
-      const daCtx = getDaCtx(req);
-      const env = {};
+        const res = await headHandler({ req, env, daCtx });
 
-      const res = await headHandler({ req, env, daCtx });
-
-      assert.strictEqual(res.headers.get('Content-Type'), 'image/png');
-      assert.strictEqual(res.headers.get('Content-Length'), '42');
+        assert.strictEqual(res.status, 404);
+      });
     });
   });
 

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import reqs from '../mocks/req.js';
+
+const { getDaCtx } = await import('../../src/utils/daCtx.js');
+const { daSourceHead } = await import('../../src/routes/da-admin.js');
+
+describe('daSourceHead', () => {
+  describe('when no authToken is present', () => {
+    it('returns 401 with no body', async () => {
+      const daCtx = getDaCtx(reqs.content); // no Authorization header → no authToken
+
+      const res = await daSourceHead({ env: {}, daCtx });
+
+      assert.strictEqual(res.status, 401);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('returns no Content-Type in the 401 response', async () => {
+      const daCtx = getDaCtx(reqs.content);
+
+      const res = await daSourceHead({ env: {}, daCtx });
+
+      assert.strictEqual(res.headers.get('Content-Type'), null);
+    });
+  });
+});


### PR DESCRIPTION
Route HEAD requests using the same logic as GET — AEM proxy (via GET) for resources, assets, and preview hosts; real HEAD call to da-admin for DA content. Also fixes the missing req parameter passed to headHandler.

