### PR TITLE
feat: add hlx6 support for api.aem.live content routing

### DIFF
--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -246,13 +246,6 @@ export async function daSourcePost({ req, env, daCtx }) {
 
     const bodyContent = toHtml(bodyNode);
     const hlx6 = await probeHlx6(org, site);
-    if (hlx6 === undefined) {
-      return new Response('Unable to determine source backend', {
-        status: 503,
-        headers: { 'Retry-After': '5' },
-      });
-    }
-
     if (hlx6) {
       const sourceUrl = aemApiSourceUrl(
         org,

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -43,12 +43,10 @@ async function probeHlx6(org, site) {
       signal: AbortSignal.timeout(UPGRADE_PROBE_TIMEOUT),
     });
     if (response.status !== 200) {
-      console.warn(`Unable to determine source backend: ${pingUrl} returned ${response.status}`);
       return undefined;
     }
     return response.headers.get('x-api-upgrade-available') === 'true';
-  } catch (e) {
-    console.warn(`Unable to determine source backend: ${pingUrl}`, e);
+  } catch {
     return undefined;
   }
 }
@@ -60,19 +58,12 @@ async function resolveUncertainWriteBackend({
   const aemUrl = aemApiSourceUrl(org, site, aemPath);
   const daUrl = new URL(`/source/${org}/${site}${daPath}`, env.DA_ADMIN);
 
-  const [aemResult, daResult] = await Promise.allSettled([
+  const [aemResult] = await Promise.allSettled([
     fetch(aemUrl, { method: 'HEAD', headers }),
     env.daadmin.fetch(daUrl, { method: 'HEAD', headers }),
   ]);
   if (aemResult.status === 'fulfilled' && aemResult.value.status === 200) {
-    if (daResult.status === 'fulfilled' && daResult.value.status === 200) {
-      console.warn(`Source document exists in both backends: ${org}/${site}${aemPath}. Using api.aem.live.`);
-    }
     return true;
-  }
-  const failure = [aemResult, daResult].find(({ status }) => status === 'rejected');
-  if (failure) {
-    console.warn(`Unable to determine source backend from document HEADs: ${org}/${site}${aemPath}. Using da-admin.`, failure.reason);
   }
   return false;
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -167,8 +167,7 @@ export async function daSourceGet({ req, env, daCtx }) {
   let sourceResp;
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, `${path}.${ext}`);
-    const sourceRequest = new Request(sourceUrl, { method: 'GET', headers });
-    sourceResp = await fetch(sourceRequest);
+    sourceResp = await fetch(sourceUrl, { headers });
   } else {
     const adminUrl = new URL(
       `/source/${org}/${site}${path}.${ext}`,

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -231,8 +231,7 @@ export async function daSourceHead({ env, daCtx }) {
   const hlx6 = await probeHlx6(org, site);
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, adminPath);
-    const response = await fetch(sourceUrl, { method: 'HEAD', headers });
-    return new Response(null, { status: response.status, headers: response.headers });
+    return fetch(sourceUrl, { method: 'HEAD', headers });
   }
 
   const adminUrl = new URL(`/source/${org}/${site}${adminPath}`, env.DA_ADMIN);

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -159,6 +159,10 @@ export async function daSourceGet({ req, env, daCtx }) {
     : await env.daadmin.fetch(sourceRequest);
   console.log(`<- ${sourceUrl.toString()}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
+  if (sourceResp.status !== 200 && sourceResp.status !== 404) {
+    return sourceResp;
+  }
+
   // use the stored content when available, otherwise fall back to a template
   const bodyHtml = sourceResp.status === 200
     ? await sourceResp.text()

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -59,11 +59,11 @@ async function probeHlx6(org, site) {
  * @returns {Promise<boolean>} true for api.aem.live, false for da-admin
  */
 async function resolveUncertainWriteBackend({
-  org, site, aemPath, daPath, authToken, env,
+  org, site, sourcePath, authToken, env,
 }) {
   const headers = new Headers({ Authorization: authToken });
-  const aemUrl = aemApiSourceUrl(org, site, aemPath);
-  const daUrl = new URL(`/source/${org}/${site}${daPath}`, env.DA_ADMIN);
+  const aemUrl = aemApiSourceUrl(org, site, sourcePath);
+  const daUrl = new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
 
   const [aemResult] = await Promise.allSettled([
     fetch(aemUrl, { method: 'HEAD', headers }),
@@ -281,23 +281,20 @@ export async function daSourcePost({ req, env, daCtx }) {
     minifyWhitespace(bodyNode);
 
     const bodyContent = toHtml(bodyNode);
-    // api.aem.live keeps explicit file extensions. Preserve da-admin's existing
-    // `${path}.${ext}` construction; HTML paths are the same for both backends.
-    const aemPath = ext !== 'html' ? path : `${path}.${ext}`;
-    const daPath = `${path}.${ext}`;
+    // daCtx.path contains explicit file extensions; append only inferred HTML.
+    const sourcePath = ext !== 'html' ? path : `${path}.${ext}`;
     let hlx6 = await probeHlx6(org, site);
     if (hlx6 === undefined) {
       hlx6 = await resolveUncertainWriteBackend({
         org,
         site,
-        aemPath,
-        daPath,
+        sourcePath,
         authToken,
         env,
       });
     }
     if (hlx6) {
-      const sourceUrl = aemApiSourceUrl(org, site, aemPath);
+      const sourceUrl = aemApiSourceUrl(org, site, sourcePath);
       const headers = {
         Authorization: authToken,
         'Content-Type': 'text/html',
@@ -318,7 +315,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     body.set('data', data);
     const headers = { Authorization: authToken };
     const adminUrl = new URL(
-      `/source/${org}/${site}${daPath}`,
+      `/source/${org}/${site}${sourcePath}`,
       env.DA_ADMIN,
     );
     // eslint-disable-next-line no-param-reassign

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -60,19 +60,19 @@ async function resolveUncertainWriteBackend({
   const aemUrl = aemApiSourceUrl(org, site, aemPath);
   const daUrl = new URL(`/source/${org}/${site}${daPath}`, env.DA_ADMIN);
 
-  try {
-    const [aemResponse, daResponse] = await Promise.all([
-      fetch(aemUrl, { method: 'HEAD', headers }),
-      env.daadmin.fetch(daUrl, { method: 'HEAD', headers }),
-    ]);
-    if (aemResponse.status === 200) {
-      if (daResponse.status === 200) {
-        console.warn(`Source document exists in both backends: ${org}/${site}${aemPath}. Using api.aem.live.`);
-      }
-      return true;
+  const [aemResult, daResult] = await Promise.allSettled([
+    fetch(aemUrl, { method: 'HEAD', headers }),
+    env.daadmin.fetch(daUrl, { method: 'HEAD', headers }),
+  ]);
+  if (aemResult.status === 'fulfilled' && aemResult.value.status === 200) {
+    if (daResult.status === 'fulfilled' && daResult.value.status === 200) {
+      console.warn(`Source document exists in both backends: ${org}/${site}${aemPath}. Using api.aem.live.`);
     }
-  } catch (e) {
-    console.warn(`Unable to determine source backend from document HEADs: ${org}/${site}${aemPath}. Using da-admin.`, e);
+    return true;
+  }
+  const failure = [aemResult, daResult].find(({ status }) => status === 'rejected');
+  if (failure) {
+    console.warn(`Unable to determine source backend from document HEADs: ${org}/${site}${aemPath}. Using da-admin.`, failure.reason);
   }
   return false;
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -138,14 +138,14 @@ export async function daSourceGet({ req, env, daCtx }) {
      and ensure that extensions are not duplicated
     */
     const hlx6 = await hlx6Promise;
-    const sourceUrl = hlx6
-      ? aemApiSourceUrl(org, site, path)
-      : new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
-    console.log(`-> ${sourceUrl.toString()}`);
-    const response = hlx6
-      ? await fetch(sourceUrl, { method: 'GET', headers })
-      : await env.daadmin.fetch(sourceUrl, { method: 'GET', headers });
-    console.log(`<- ${sourceUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+    if (hlx6) {
+      const sourceUrl = aemApiSourceUrl(org, site, path);
+      return fetch(sourceUrl, { method: 'GET', headers });
+    }
+    const adminUrl = new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
+    console.log(`-> ${adminUrl.toString()}`);
+    const response = await env.daadmin.fetch(adminUrl, { method: 'GET', headers });
+    console.log(`<- ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
     return response;
   }
 
@@ -164,15 +164,26 @@ export async function daSourceGet({ req, env, daCtx }) {
     return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
   }
 
-  const sourceUrl = hlx6
-    ? aemApiSourceUrl(org, site, `${path}.${ext}`)
-    : new URL(`/source/${org}/${site}${path}.${ext}`, env.DA_ADMIN);
-  const sourceRequest = new Request(sourceUrl, { method: 'GET', headers });
-  console.log(`-> ${sourceUrl.toString()}`);
-  const sourceResp = hlx6
-    ? await fetch(sourceRequest)
-    : await env.daadmin.fetch(sourceRequest);
-  console.log(`<- ${sourceUrl.toString()}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
+  let sourceResp;
+  if (hlx6) {
+    const sourceUrl = aemApiSourceUrl(org, site, `${path}.${ext}`);
+    const sourceRequest = new Request(sourceUrl, { method: 'GET', headers });
+    sourceResp = await fetch(sourceRequest);
+  } else {
+    const adminUrl = new URL(
+      `/source/${org}/${site}${path}.${ext}`,
+      env.DA_ADMIN,
+    );
+    // eslint-disable-next-line no-param-reassign
+    req = new Request(adminUrl, {
+      method: 'GET',
+      headers,
+    });
+    console.log(`-> ${adminUrl.toString()}`);
+    const daAdminResp = await env.daadmin.fetch(req);
+    console.log(`<- ${adminUrl.toString()}. ${daAdminResp.status} ${daAdminResp.statusText}`, { status: daAdminResp.status, statusText: daAdminResp.statusText });
+    sourceResp = daAdminResp;
+  }
 
   if (sourceResp.status !== 200 && sourceResp.status !== 404) {
     return sourceResp;
@@ -226,9 +237,7 @@ export async function daSourceHead({ env, daCtx }) {
   const hlx6 = await probeHlx6(org, site);
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, adminPath);
-    console.log(`-> HEAD ${sourceUrl}`);
     const response = await fetch(sourceUrl, { method: 'HEAD', headers });
-    console.log(`<- HEAD ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
     return new Response(null, { status: response.status, headers: response.headers });
   }
 
@@ -283,13 +292,11 @@ export async function daSourcePost({ req, env, daCtx }) {
         Authorization: authToken,
         'Content-Type': 'text/html',
       };
-      console.log(`-> ${sourceUrl}`);
       const response = await fetch(sourceUrl, {
         method: 'POST',
         body: bodyContent,
         headers,
       });
-      console.log(`<- ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
       return response;
     }
 

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -140,7 +140,7 @@ export async function daSourceGet({ req, env, daCtx }) {
     const hlx6 = await hlx6Promise;
     if (hlx6) {
       const sourceUrl = aemApiSourceUrl(org, site, path);
-      return fetch(sourceUrl, { method: 'GET', headers });
+      return fetch(sourceUrl, { headers });
     }
     const adminUrl = new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
     console.log(`-> ${adminUrl.toString()}`);

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -28,6 +28,76 @@ import { BRANCH_NOT_FOUND_HTML_MESSAGE, DEFAULT_HTML_TEMPLATE, UNAUTHORIZED_HTML
 import { getSiteConfig } from '../storage/config.js';
 import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
+const AEM_API = 'https://api.aem.live';
+const HLX_ADMIN = 'https://admin.hlx.page';
+const UPGRADE_CACHE_TTL = 5 * 60 * 1000;
+const UPGRADE_ERROR_TTL = 5 * 1000;
+const UPGRADE_PROBE_TIMEOUT = 2 * 1000;
+const sourceBackendCache = new Map();
+
+function aemApiSourceUrl(org, site, path) {
+  return `${AEM_API}/${org}/sites/${site}/source${path}`;
+}
+
+async function probeHlx6(org, site) {
+  const pingUrl = `${HLX_ADMIN}/ping/${org}/${site}`;
+  try {
+    const response = await fetch(pingUrl, {
+      signal: AbortSignal.timeout(UPGRADE_PROBE_TIMEOUT),
+    });
+    if (response.status !== 200) {
+      console.warn(`Unable to determine source backend: ${pingUrl} returned ${response.status}`);
+      return undefined;
+    }
+    return response.headers.get('x-api-upgrade-available') === 'true';
+  } catch (e) {
+    if (e instanceof TypeError || e.name === 'AbortError' || e.name === 'TimeoutError') {
+      console.warn(`Unable to determine source backend: ${pingUrl}`, e);
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+async function resolveHlx6(org, site) {
+  const key = `${org}/${site}`;
+  const now = Date.now();
+  const cached = sourceBackendCache.get(key);
+  if (cached?.expiresAt > now) return cached.value;
+  if (cached?.pending) return cached.pending;
+
+  const staleValue = cached?.value;
+  const pending = probeHlx6(org, site)
+    .then((value) => {
+      if (value === undefined) {
+        sourceBackendCache.set(key, {
+          value: staleValue,
+          expiresAt: Date.now() + UPGRADE_ERROR_TTL,
+        });
+        return staleValue;
+      }
+
+      sourceBackendCache.set(key, {
+        value,
+        expiresAt: Date.now() + UPGRADE_CACHE_TTL,
+      });
+      return value;
+    })
+    .catch((e) => {
+      if (staleValue === undefined) {
+        sourceBackendCache.delete(key);
+      } else {
+        sourceBackendCache.set(key, {
+          value: staleValue,
+          expiresAt: Date.now() + UPGRADE_ERROR_TTL,
+        });
+      }
+      throw e;
+    });
+  sourceBackendCache.set(key, { ...cached, pending });
+  return pending;
+}
+
 async function getFileBody(data) {
   const text = await data.text();
   return { body: text, type: data.type };
@@ -90,21 +160,31 @@ export async function daSourceGet({ req, env, daCtx }) {
   const headers = new Headers();
   headers.set('Authorization', authToken);
 
+  const hlx6Promise = resolveHlx6(org, site);
+
   if (ext !== 'html') {
     /*
      for non-HTML files, simply proxy the request without processing
      and ensure that extensions are not duplicated
     */
-    const adminUrl = new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
-    console.log(`-> ${adminUrl.toString()}`);
-    const response = await env.daadmin.fetch(adminUrl, { method: 'GET', headers });
-    console.log(`<- ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+    const hlx6 = await hlx6Promise;
+    const sourceUrl = hlx6
+      ? aemApiSourceUrl(org, site, path)
+      : new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
+    console.log(`-> ${sourceUrl.toString()}`);
+    const response = hlx6
+      ? await fetch(sourceUrl, { method: 'GET', headers })
+      : await env.daadmin.fetch(sourceUrl, { method: 'GET', headers });
+    console.log(`<- ${sourceUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
     return response;
   }
 
   // get the AEM parts (head.html)
   const aemCtx = getAemCtx(env, daCtx);
-  const headHtml = await getAEMHtml(aemCtx, '/head.html');
+  const [headHtml, hlx6] = await Promise.all([
+    getAEMHtml(aemCtx, '/head.html'),
+    hlx6Promise,
+  ]);
   if (!headHtml) {
     // quick-edit still needs a working shell (with the import map) so the editor
     // can load into this page, even when the AEM branch doesn't exist yet.
@@ -114,24 +194,19 @@ export async function daSourceGet({ req, env, daCtx }) {
     return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
   }
 
-  // get the content from DA admin
-  const adminUrl = new URL(
-    `/source/${org}/${site}${path}.${ext}`,
-    env.DA_ADMIN,
-  );
-
-  // eslint-disable-next-line no-param-reassign
-  req = new Request(adminUrl, {
-    method: 'GET',
-    headers,
-  });
-  console.log(`-> ${adminUrl.toString()}`);
-  const daAdminResp = await env.daadmin.fetch(req);
-  console.log(`<- ${adminUrl.toString()}. ${daAdminResp.status} ${daAdminResp.statusText}`, { status: daAdminResp.status, statusText: daAdminResp.statusText });
+  const sourceUrl = hlx6
+    ? aemApiSourceUrl(org, site, `${path}.${ext}`)
+    : new URL(`/source/${org}/${site}${path}.${ext}`, env.DA_ADMIN);
+  const sourceRequest = new Request(sourceUrl, { method: 'GET', headers });
+  console.log(`-> ${sourceUrl.toString()}`);
+  const sourceResp = hlx6
+    ? await fetch(sourceRequest)
+    : await env.daadmin.fetch(sourceRequest);
+  console.log(`<- ${sourceUrl.toString()}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
   // use the stored content when available, otherwise fall back to a template
-  const bodyHtml = daAdminResp && daAdminResp.status === 200
-    ? await daAdminResp.text()
+  const bodyHtml = sourceResp.status === 200
+    ? await sourceResp.text()
     : await getPageTemplate(env, daCtx, aemCtx, headHtml);
 
   // compose the page the same way for every request type
@@ -174,6 +249,15 @@ export async function daSourceHead({ env, daCtx }) {
   headers.set('Authorization', authToken);
 
   const adminPath = ext !== 'html' ? path : `${path}.${ext}`;
+  const hlx6 = await resolveHlx6(org, site);
+  if (hlx6) {
+    const sourceUrl = aemApiSourceUrl(org, site, adminPath);
+    console.log(`-> HEAD ${sourceUrl}`);
+    const response = await fetch(sourceUrl, { method: 'HEAD', headers });
+    console.log(`<- HEAD ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+    return new Response(null, { status: response.status, headers: response.headers });
+  }
+
   const adminUrl = new URL(`/source/${org}/${site}${adminPath}`, env.DA_ADMIN);
   console.log(`-> HEAD ${adminUrl.toString()}`);
   const response = await env.daadmin.fetch(adminUrl, { method: 'HEAD', headers });
@@ -205,9 +289,37 @@ export async function daSourcePost({ req, env, daCtx }) {
 
     minifyWhitespace(bodyNode);
 
+    const bodyContent = toHtml(bodyNode);
+    const hlx6 = await resolveHlx6(org, site);
+    if (hlx6 === undefined) {
+      return new Response('Unable to determine source backend', {
+        status: 503,
+        headers: { 'Retry-After': '5' },
+      });
+    }
+
+    if (hlx6) {
+      const sourceUrl = aemApiSourceUrl(
+        org,
+        site,
+        ext !== 'html' ? path : `${path}.${ext}`,
+      );
+      const headers = {
+        Authorization: authToken,
+        'Content-Type': 'text/html',
+      };
+      console.log(`-> ${sourceUrl}`);
+      const response = await fetch(sourceUrl, {
+        method: 'POST',
+        body: bodyContent,
+        headers,
+      });
+      console.log(`<- ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+      return response;
+    }
+
     // create new POST request with the body content
     const body = new FormData();
-    const bodyContent = toHtml(bodyNode);
     const data = new Blob([bodyContent], { type: 'text/html' });
     body.set('data', data);
     const headers = { Authorization: authToken };

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -48,11 +48,8 @@ async function probeHlx6(org, site) {
     }
     return response.headers.get('x-api-upgrade-available') === 'true';
   } catch (e) {
-    if (e instanceof TypeError || e.name === 'AbortError' || e.name === 'TimeoutError') {
-      console.warn(`Unable to determine source backend: ${pingUrl}`, e);
-      return undefined;
-    }
-    throw e;
+    console.warn(`Unable to determine source backend: ${pingUrl}`, e);
+    return undefined;
   }
 }
 

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -53,6 +53,30 @@ async function probeHlx6(org, site) {
   }
 }
 
+async function resolveUncertainWriteBackend({
+  org, site, aemPath, daPath, authToken, env,
+}) {
+  const headers = new Headers({ Authorization: authToken });
+  const aemUrl = aemApiSourceUrl(org, site, aemPath);
+  const daUrl = new URL(`/source/${org}/${site}${daPath}`, env.DA_ADMIN);
+
+  try {
+    const [aemResponse, daResponse] = await Promise.all([
+      fetch(aemUrl, { method: 'HEAD', headers }),
+      env.daadmin.fetch(daUrl, { method: 'HEAD', headers }),
+    ]);
+    if (aemResponse.status === 200) {
+      if (daResponse.status === 200) {
+        console.warn(`Source document exists in both backends: ${org}/${site}${aemPath}. Using api.aem.live.`);
+      }
+      return true;
+    }
+  } catch (e) {
+    console.warn(`Unable to determine source backend from document HEADs: ${org}/${site}${aemPath}. Using da-admin.`, e);
+  }
+  return false;
+}
+
 async function getFileBody(data) {
   const text = await data.text();
   return { body: text, type: data.type };
@@ -249,13 +273,21 @@ export async function daSourcePost({ req, env, daCtx }) {
     minifyWhitespace(bodyNode);
 
     const bodyContent = toHtml(bodyNode);
-    const hlx6 = await probeHlx6(org, site);
-    if (hlx6) {
-      const sourceUrl = aemApiSourceUrl(
+    const aemPath = ext !== 'html' ? path : `${path}.${ext}`;
+    const daPath = `${path}.${ext}`;
+    let hlx6 = await probeHlx6(org, site);
+    if (hlx6 === undefined) {
+      hlx6 = await resolveUncertainWriteBackend({
         org,
         site,
-        ext !== 'html' ? path : `${path}.${ext}`,
-      );
+        aemPath,
+        daPath,
+        authToken,
+        env,
+      });
+    }
+    if (hlx6) {
+      const sourceUrl = aemApiSourceUrl(org, site, aemPath);
       const headers = {
         Authorization: authToken,
         'Content-Type': 'text/html',
@@ -276,7 +308,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     body.set('data', data);
     const headers = { Authorization: authToken };
     const adminUrl = new URL(
-      `/source/${org}/${site}${path}.${ext}`,
+      `/source/${org}/${site}${daPath}`,
       env.DA_ADMIN,
     );
     // eslint-disable-next-line no-param-reassign

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -30,10 +30,7 @@ import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
 const AEM_API = 'https://api.aem.live';
 const HLX_ADMIN = 'https://admin.hlx.page';
-const UPGRADE_CACHE_TTL = 5 * 60 * 1000;
-const UPGRADE_ERROR_TTL = 5 * 1000;
 const UPGRADE_PROBE_TIMEOUT = 2 * 1000;
-const sourceBackendCache = new Map();
 
 function aemApiSourceUrl(org, site, path) {
   return `${AEM_API}/${org}/sites/${site}/source${path}`;
@@ -57,45 +54,6 @@ async function probeHlx6(org, site) {
     }
     throw e;
   }
-}
-
-async function resolveHlx6(org, site) {
-  const key = `${org}/${site}`;
-  const now = Date.now();
-  const cached = sourceBackendCache.get(key);
-  if (cached?.expiresAt > now) return cached.value;
-  if (cached?.pending) return cached.pending;
-
-  const staleValue = cached?.value;
-  const pending = probeHlx6(org, site)
-    .then((value) => {
-      if (value === undefined) {
-        sourceBackendCache.set(key, {
-          value: staleValue,
-          expiresAt: Date.now() + UPGRADE_ERROR_TTL,
-        });
-        return staleValue;
-      }
-
-      sourceBackendCache.set(key, {
-        value,
-        expiresAt: Date.now() + UPGRADE_CACHE_TTL,
-      });
-      return value;
-    })
-    .catch((e) => {
-      if (staleValue === undefined) {
-        sourceBackendCache.delete(key);
-      } else {
-        sourceBackendCache.set(key, {
-          value: staleValue,
-          expiresAt: Date.now() + UPGRADE_ERROR_TTL,
-        });
-      }
-      throw e;
-    });
-  sourceBackendCache.set(key, { ...cached, pending });
-  return pending;
 }
 
 async function getFileBody(data) {
@@ -160,7 +118,7 @@ export async function daSourceGet({ req, env, daCtx }) {
   const headers = new Headers();
   headers.set('Authorization', authToken);
 
-  const hlx6Promise = resolveHlx6(org, site);
+  const hlx6Promise = probeHlx6(org, site);
 
   if (ext !== 'html') {
     /*
@@ -249,7 +207,7 @@ export async function daSourceHead({ env, daCtx }) {
   headers.set('Authorization', authToken);
 
   const adminPath = ext !== 'html' ? path : `${path}.${ext}`;
-  const hlx6 = await resolveHlx6(org, site);
+  const hlx6 = await probeHlx6(org, site);
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, adminPath);
     console.log(`-> HEAD ${sourceUrl}`);
@@ -290,7 +248,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     minifyWhitespace(bodyNode);
 
     const bodyContent = toHtml(bodyNode);
-    const hlx6 = await resolveHlx6(org, site);
+    const hlx6 = await probeHlx6(org, site);
     if (hlx6 === undefined) {
       return new Response('Unable to determine source backend', {
         status: 503,

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -173,13 +173,8 @@ export async function daSourceGet({ req, env, daCtx }) {
       `/source/${org}/${site}${path}.${ext}`,
       env.DA_ADMIN,
     );
-    // eslint-disable-next-line no-param-reassign
-    req = new Request(adminUrl, {
-      method: 'GET',
-      headers,
-    });
     console.log(`-> ${adminUrl.toString()}`);
-    const daAdminResp = await env.daadmin.fetch(req);
+    const daAdminResp = await env.daadmin.fetch(adminUrl, { headers });
     console.log(`<- ${adminUrl.toString()}. ${daAdminResp.status} ${daAdminResp.statusText}`, { status: daAdminResp.status, statusText: daAdminResp.statusText });
     sourceResp = daAdminResp;
   }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -51,6 +51,13 @@ async function probeHlx6(org, site) {
   }
 }
 
+/**
+ * Resolves the write backend after the site probe fails.
+ * Both backends are HEADed concurrently. A source-bus 200 selects api.aem.live.
+ * Every other result selects da-admin, including a missing document or failed HEAD.
+ *
+ * @returns {Promise<boolean>} true for api.aem.live, false for da-admin
+ */
 async function resolveUncertainWriteBackend({
   org, site, aemPath, daPath, authToken, env,
 }) {
@@ -140,7 +147,10 @@ export async function daSourceGet({ req, env, daCtx }) {
     const hlx6 = await hlx6Promise;
     if (hlx6) {
       const sourceUrl = aemApiSourceUrl(org, site, path);
-      return fetch(sourceUrl, { headers });
+      console.log(`-> ${sourceUrl}`);
+      const response = await fetch(sourceUrl, { headers });
+      console.log(`<- ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+      return response;
     }
     const adminUrl = new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
     console.log(`-> ${adminUrl.toString()}`);
@@ -167,7 +177,9 @@ export async function daSourceGet({ req, env, daCtx }) {
   let sourceResp;
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, `${path}.${ext}`);
+    console.log(`-> ${sourceUrl}`);
     sourceResp = await fetch(sourceUrl, { headers });
+    console.log(`<- ${sourceUrl}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
   } else {
     const adminUrl = new URL(
       `/source/${org}/${site}${path}.${ext}`,
@@ -231,7 +243,10 @@ export async function daSourceHead({ env, daCtx }) {
   const hlx6 = await probeHlx6(org, site);
   if (hlx6) {
     const sourceUrl = aemApiSourceUrl(org, site, adminPath);
-    return fetch(sourceUrl, { method: 'HEAD', headers });
+    console.log(`-> HEAD ${sourceUrl}`);
+    const response = await fetch(sourceUrl, { method: 'HEAD', headers });
+    console.log(`<- HEAD ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
+    return response;
   }
 
   const adminUrl = new URL(`/source/${org}/${site}${adminPath}`, env.DA_ADMIN);
@@ -266,6 +281,8 @@ export async function daSourcePost({ req, env, daCtx }) {
     minifyWhitespace(bodyNode);
 
     const bodyContent = toHtml(bodyNode);
+    // api.aem.live keeps explicit file extensions. Preserve da-admin's existing
+    // `${path}.${ext}` construction; HTML paths are the same for both backends.
     const aemPath = ext !== 'html' ? path : `${path}.${ext}`;
     const daPath = `${path}.${ext}`;
     let hlx6 = await probeHlx6(org, site);
@@ -285,11 +302,13 @@ export async function daSourcePost({ req, env, daCtx }) {
         Authorization: authToken,
         'Content-Type': 'text/html',
       };
+      console.log(`-> ${sourceUrl}`);
       const response = await fetch(sourceUrl, {
         method: 'POST',
         body: bodyContent,
         headers,
       });
+      console.log(`<- ${sourceUrl}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
       return response;
     }
 

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -49,6 +49,16 @@ describe('daSourceGet', () => {
 
   // record which composition / instrumentation calls happen and with what
   let calls;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('', { status: 200 });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
 
   const mockDaSourceGet = async (overrides = {}) => {
     // 'headHtml' in overrides (rather than a destructured default) so passing

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import esmock from 'esmock';
+import { getDaCtx } from '../../src/utils/daCtx.js';
+
+const ORG = 'org';
+const SITE = 'site';
+const AUTH = 'Bearer test-token';
+const DA_ADMIN = 'https://admin.da.live';
+const HLX_ADMIN = 'https://admin.hlx.page';
+const AEM_API = 'https://api.aem.live';
+const PING_URL = `${HLX_ADMIN}/ping/${ORG}/${SITE}`;
+
+function callDetails(input, init = {}) {
+  const request = input instanceof Request ? input : null;
+  return {
+    input,
+    url: request?.url ?? String(input),
+    method: init.method ?? request?.method ?? 'GET',
+    headers: new Headers(init.headers ?? request?.headers),
+    body: init.body,
+  };
+}
+
+describe('source backend routing', () => {
+  let originalFetch;
+  let originalDateNow;
+  let fetchCalls;
+  let daAdminCalls;
+  let fetchResponse;
+  let daAdminResponse;
+  let composedBodies;
+  let env;
+
+  const authedRequest = (path, init = {}) => new Request(
+    `https://main--${SITE}--${ORG}.preview.da.live${path}`,
+    {
+      ...init,
+      headers: {
+        Authorization: AUTH,
+        ...init.headers,
+      },
+    },
+  );
+
+  const loadRoutes = async () => esmock('../../src/routes/da-admin.js', {
+    '../../src/utils/aemCtx.js': {
+      getAemCtx: () => ({}),
+      getAEMHtml: async () => '<script src="/scripts.js"></script>',
+    },
+    '../../src/render/compose.js': {
+      composeHtml: async (daCtx, aemCtx, bodyHtml) => {
+        composedBodies.push(bodyHtml);
+        return { bodyHtml };
+      },
+      serializeHtml: ({ bodyHtml }) => `<html>${bodyHtml}</html>`,
+    },
+    '../../src/helpers/source.js': {
+      default: async () => ({ data: '<body><main>edited</main></body>' }),
+    },
+    '../../src/ue/attributes.js': {
+      removeUEAttributes: (node) => node,
+      unwrapParagraphs: (node) => node,
+    },
+    '../../src/render/rewrite-images.js': {
+      restoreAbsoluteImages: () => {},
+    },
+  });
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalDateNow = Date.now;
+    fetchCalls = [];
+    daAdminCalls = [];
+    composedBodies = [];
+    fetchResponse = async () => new Response('', { status: 404 });
+    daAdminResponse = async () => new Response('', { status: 404 });
+
+    globalThis.fetch = async (input, init) => {
+      const details = callDetails(input, init);
+      fetchCalls.push(details);
+      return fetchResponse(details);
+    };
+    env = {
+      DA_ADMIN,
+      daadmin: {
+        fetch: async (input, init) => {
+          const details = callDetails(input, init);
+          daAdminCalls.push(details);
+          return daAdminResponse(details);
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Date.now = originalDateNow;
+  });
+
+  function upgradeResponse(upgraded = true) {
+    return new Response('', {
+      status: 200,
+      headers: upgraded ? { 'x-api-upgrade-available': 'true' } : {},
+    });
+  }
+
+  it('GETs a source-bus asset from api.aem.live', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/image.png`;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) return upgradeResponse();
+      if (url === sourceUrl) return new Response('source image', { status: 200 });
+      return new Response('', { status: 500 });
+    };
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(await response.text(), 'source image');
+    assert.strictEqual(daAdminCalls.length, 0);
+    assert.strictEqual(fetchCalls[0].url, PING_URL);
+    assert.strictEqual(fetchCalls[0].headers.get('Authorization'), null);
+    assert.strictEqual(fetchCalls[1].url, sourceUrl);
+    assert.strictEqual(fetchCalls[1].headers.get('Authorization'), AUTH);
+  });
+
+  it('composes source-bus HTML through the existing preview pipeline', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) return upgradeResponse();
+      if (url === sourceUrl) {
+        return new Response('<body><main>source page</main></body>', { status: 200 });
+      }
+      return new Response('', { status: 500 });
+    };
+    const req = authedRequest('/page');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(composedBodies, ['<body><main>source page</main></body>']);
+    assert.strictEqual(await response.text(), '<html><body><main>source page</main></body></html>');
+    assert.strictEqual(daAdminCalls.length, 0);
+  });
+
+  it('does not fall back to legacy content when a source-bus resource is missing', async () => {
+    fetchResponse = async ({ url }) => (
+      url === PING_URL ? upgradeResponse() : new Response('', { status: 404 })
+    );
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
+    const req = authedRequest('/missing.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 404);
+    assert.strictEqual(daAdminCalls.length, 0);
+  });
+
+  it('GETs legacy content when ping has no upgrade header', async () => {
+    fetchResponse = async ({ url }) => (
+      url === PING_URL ? upgradeResponse(false) : new Response('', { status: 500 })
+    );
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(await response.text(), 'legacy image');
+    assert.strictEqual(fetchCalls.length, 1);
+    assert.strictEqual(daAdminCalls.length, 1);
+    assert.strictEqual(
+      daAdminCalls[0].url,
+      `${DA_ADMIN}/source/${ORG}/${SITE}/image.png`,
+    );
+    assert.strictEqual(daAdminCalls[0].headers.get('Authorization'), AUTH);
+  });
+
+  [401, 403, 404, 500].forEach((status) => {
+    it(`falls back to legacy GET when ping returns ${status}`, async () => {
+      fetchResponse = async () => new Response('', { status });
+      daAdminResponse = async () => new Response('legacy image', { status: 200 });
+      const req = authedRequest('/image.png');
+      const daCtx = getDaCtx(req);
+      const { daSourceGet } = await loadRoutes();
+
+      const response = await daSourceGet({ req, env, daCtx });
+
+      assert.strictEqual(await response.text(), 'legacy image');
+      assert.strictEqual(fetchCalls.length, 1);
+      assert.strictEqual(daAdminCalls.length, 1);
+    });
+  });
+
+  it('falls back to legacy GET when ping fails', async () => {
+    fetchResponse = async () => {
+      throw new TypeError('network failure');
+    };
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(await response.text(), 'legacy image');
+    assert.strictEqual(daAdminCalls.length, 1);
+  });
+
+  it('HEADs a source-bus resource through api.aem.live', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/image.png`;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) return upgradeResponse();
+      if (url === sourceUrl) {
+        return new Response(null, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png', 'Content-Length': '42' },
+        });
+      }
+      return new Response('', { status: 500 });
+    };
+    const req = authedRequest('/image.png', { method: 'HEAD' });
+    const daCtx = getDaCtx(req);
+    const { daSourceHead } = await loadRoutes();
+
+    const response = await daSourceHead({ env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.headers.get('Content-Type'), 'image/png');
+    assert.strictEqual(response.headers.get('Content-Length'), '42');
+    assert.deepStrictEqual(fetchCalls.map(({ method }) => method), ['GET', 'HEAD']);
+    assert.strictEqual(daAdminCalls.length, 0);
+  });
+
+  it('POSTs raw HTML to api.aem.live and does not write to da-admin', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) return upgradeResponse();
+      if (url === sourceUrl) return new Response('', { status: 201 });
+      return new Response('', { status: 500 });
+    };
+    const req = authedRequest('/page', { method: 'POST' });
+    const daCtx = getDaCtx(req);
+    const { daSourcePost } = await loadRoutes();
+
+    const response = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 201);
+    const post = fetchCalls.find(({ method }) => method === 'POST');
+    assert.ok(post);
+    assert.strictEqual(post.url, sourceUrl);
+    assert.strictEqual(post.headers.get('Authorization'), AUTH);
+    assert.strictEqual(post.headers.get('Content-Type'), 'text/html');
+    assert.strictEqual(post.body, '<body><main>edited</main></body>');
+    assert.strictEqual(daAdminCalls.length, 0);
+  });
+
+  it('POSTs FormData to da-admin and does not write to api.aem.live for legacy sites', async () => {
+    fetchResponse = async () => upgradeResponse(false);
+    daAdminResponse = async () => new Response('', { status: 200 });
+    const req = authedRequest('/page', { method: 'POST' });
+    const daCtx = getDaCtx(req);
+    const { daSourcePost } = await loadRoutes();
+
+    const response = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(fetchCalls.length, 1);
+    assert.strictEqual(daAdminCalls.length, 1);
+    assert.strictEqual(daAdminCalls[0].method, 'POST');
+    const body = await daAdminCalls[0].input.clone().formData();
+    assert.strictEqual(
+      await body.get('data').text(),
+      '<body><main>edited</main></body>',
+    );
+  });
+
+  [401, 403, 404, 500].forEach((status) => {
+    it(`returns 503 without writing when POST ping returns ${status}`, async () => {
+      fetchResponse = async () => new Response('', { status });
+      daAdminResponse = async () => new Response('', { status: 200 });
+      const req = authedRequest('/page', { method: 'POST' });
+      const daCtx = getDaCtx(req);
+      const { daSourcePost } = await loadRoutes();
+
+      const response = await daSourcePost({ req, env, daCtx });
+
+      assert.strictEqual(response.status, 503);
+      assert.strictEqual(fetchCalls.length, 1);
+      assert.strictEqual(daAdminCalls.length, 0);
+    });
+  });
+
+  [
+    new TypeError('network failure'),
+    new DOMException('timed out', 'AbortError'),
+  ].forEach((error) => {
+    it(`returns 503 without writing when POST ping fails with ${error.name}`, async () => {
+      fetchResponse = async () => {
+        throw error;
+      };
+      const req = authedRequest('/page', { method: 'POST' });
+      const daCtx = getDaCtx(req);
+      const { daSourcePost } = await loadRoutes();
+
+      const response = await daSourcePost({ req, env, daCtx });
+
+      assert.strictEqual(response.status, 503);
+      assert.strictEqual(fetchCalls.length, 1);
+      assert.strictEqual(daAdminCalls.length, 0);
+    });
+  });
+
+  it('refreshes the routing decision after five minutes to allow rollback', async () => {
+    let now = 1_000;
+    let upgraded = true;
+    Date.now = () => now;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) return upgradeResponse(upgraded);
+      return new Response('source image', { status: 200 });
+    };
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const first = await daSourceGet({ req, env, daCtx });
+    upgraded = false;
+    now += 300_001;
+    const second = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(await first.text(), 'source image');
+    assert.strictEqual(await second.text(), 'legacy image');
+    assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
+    assert.strictEqual(daAdminCalls.length, 1);
+  });
+
+  it('uses a stale routing decision when a refresh fails', async () => {
+    let now = 1_000;
+    let pingStatus = 200;
+    Date.now = () => now;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL) {
+        return pingStatus === 200
+          ? upgradeResponse()
+          : new Response('', { status: pingStatus });
+      }
+      return new Response('source image', { status: 200 });
+    };
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    const first = await daSourceGet({ req, env, daCtx });
+    pingStatus = 500;
+    now += 300_001;
+    const second = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(await first.text(), 'source image');
+    assert.strictEqual(await second.text(), 'source image');
+    assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
+    assert.strictEqual(daAdminCalls.length, 0);
+  });
+});

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -211,7 +211,7 @@ describe('source backend routing', () => {
   });
 
   [
-    new TypeError('network failure'),
+    new Error('Network connection lost.'),
     new DOMException('timed out', 'TimeoutError'),
   ].forEach((error) => {
     it(`falls back to legacy GET when ping fails with ${error.name}`, async () => {
@@ -315,7 +315,7 @@ describe('source backend routing', () => {
   });
 
   [
-    new TypeError('network failure'),
+    new Error('Network connection lost.'),
     new DOMException('timed out', 'TimeoutError'),
   ].forEach((error) => {
     it(`returns 503 without writing when POST ping fails with ${error.name}`, async () => {
@@ -334,24 +334,26 @@ describe('source backend routing', () => {
     });
   });
 
-  it('retries after an unexpected probe error instead of caching the rejection', async () => {
+  it('falls back after a probe error and probes again on the next request', async () => {
     let firstProbe = true;
     fetchResponse = async ({ url }) => {
       if (url === PING_URL && firstProbe) {
         firstProbe = false;
-        throw new Error('unexpected failure');
+        throw new Error('internal error; reference = test');
       }
       if (url === PING_URL) return upgradeResponse();
       return new Response('source image', { status: 200 });
     };
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
     const req = authedRequest('/image.png');
     const daCtx = getDaCtx(req);
     const { daSourceGet } = await loadRoutes();
 
-    await assert.rejects(() => daSourceGet({ req, env, daCtx }), /unexpected failure/);
-    const response = await daSourceGet({ req, env, daCtx });
+    const first = await daSourceGet({ req, env, daCtx });
+    const second = await daSourceGet({ req, env, daCtx });
 
-    assert.strictEqual(await response.text(), 'source image');
+    assert.strictEqual(await first.text(), 'legacy image');
+    assert.strictEqual(await second.text(), 'source image');
     assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
   });
 

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -299,7 +299,7 @@ describe('source backend routing', () => {
   });
 
   [401, 403, 404, 500].forEach((status) => {
-    it(`returns 503 without writing when POST ping returns ${status}`, async () => {
+    it(`POSTs to da-admin when ping returns ${status}`, async () => {
       fetchResponse = async () => new Response('', { status });
       daAdminResponse = async () => new Response('', { status: 200 });
       const req = authedRequest('/page', { method: 'POST' });
@@ -308,9 +308,11 @@ describe('source backend routing', () => {
 
       const response = await daSourcePost({ req, env, daCtx });
 
-      assert.strictEqual(response.status, 503);
+      assert.strictEqual(response.status, 200);
       assert.strictEqual(fetchCalls.length, 1);
-      assert.strictEqual(daAdminCalls.length, 0);
+      assert.strictEqual(fetchCalls[0].method, 'GET');
+      assert.strictEqual(daAdminCalls.length, 1);
+      assert.strictEqual(daAdminCalls[0].method, 'POST');
     });
   });
 
@@ -318,19 +320,22 @@ describe('source backend routing', () => {
     new Error('Network connection lost.'),
     new DOMException('timed out', 'TimeoutError'),
   ].forEach((error) => {
-    it(`returns 503 without writing when POST ping fails with ${error.name}`, async () => {
+    it(`POSTs to da-admin when ping fails with ${error.name}`, async () => {
       fetchResponse = async () => {
         throw error;
       };
+      daAdminResponse = async () => new Response('', { status: 200 });
       const req = authedRequest('/page', { method: 'POST' });
       const daCtx = getDaCtx(req);
       const { daSourcePost } = await loadRoutes();
 
       const response = await daSourcePost({ req, env, daCtx });
 
-      assert.strictEqual(response.status, 503);
+      assert.strictEqual(response.status, 200);
       assert.strictEqual(fetchCalls.length, 1);
-      assert.strictEqual(daAdminCalls.length, 0);
+      assert.strictEqual(fetchCalls[0].method, 'GET');
+      assert.strictEqual(daAdminCalls.length, 1);
+      assert.strictEqual(daAdminCalls[0].method, 'POST');
     });
   });
 

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -442,6 +442,36 @@ describe('source backend routing', () => {
     assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'POST').length, 1);
   });
 
+  it('preserves explicit extensions when an uncertain write uses da-admin', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/sheet.json`;
+    const adminUrl = `${DA_ADMIN}/source/${ORG}/${SITE}/sheet.json`;
+    fetchResponse = async ({ url, method }) => {
+      if (url === PING_URL) return new Response('', { status: 500 });
+      if (url === sourceUrl && method === 'HEAD') {
+        return new Response(null, { status: 404 });
+      }
+      return new Response('', { status: 500 });
+    };
+    daAdminResponse = async ({ method }) => (
+      new Response(null, { status: method === 'HEAD' ? 200 : 200 })
+    );
+    const req = authedRequest('/sheet.json', { method: 'POST' });
+    const daCtx = getDaCtx(req);
+    const { daSourcePost } = await loadRoutes();
+
+    const response = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(
+      daAdminCalls.find(({ method }) => method === 'HEAD').url,
+      adminUrl,
+    );
+    assert.strictEqual(
+      daAdminCalls.find(({ method }) => method === 'POST').url,
+      adminUrl,
+    );
+  });
+
   it('uses api.aem.live when its HEAD succeeds and da-admin HEAD fails', async () => {
     const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
     fetchResponse = async ({ url, method }) => {

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -147,7 +147,10 @@ describe('source backend routing', () => {
     assert.strictEqual(fetchCalls[0].headers.get('Authorization'), null);
     assert.strictEqual(fetchCalls[1].url, sourceUrl);
     assert.strictEqual(fetchCalls[1].headers.get('Authorization'), AUTH);
-    assert.strictEqual(logs.length, 0);
+    assert.deepStrictEqual(logs.map(([message]) => message), [
+      `-> ${sourceUrl}`,
+      `<- ${sourceUrl}. 200 `,
+    ]);
   });
 
   it('composes source-bus HTML through the existing preview pipeline', async () => {
@@ -169,7 +172,10 @@ describe('source backend routing', () => {
     assert.deepStrictEqual(composedBodies, ['<body><main>source page</main></body>']);
     assert.strictEqual(await response.text(), '<html><body><main>source page</main></body></html>');
     assert.strictEqual(daAdminCalls.length, 0);
-    assert.strictEqual(logs.length, 0);
+    assert.deepStrictEqual(logs.map(([message]) => message), [
+      `-> ${sourceUrl}`,
+      `<- ${sourceUrl}. 200 `,
+    ]);
   });
 
   [401, 403, 500, 503].forEach((status) => {
@@ -293,7 +299,10 @@ describe('source backend routing', () => {
     assert.strictEqual(response.headers.get('Content-Length'), '42');
     assert.deepStrictEqual(fetchCalls.map(({ method }) => method), ['GET', 'HEAD']);
     assert.strictEqual(daAdminCalls.length, 0);
-    assert.strictEqual(logs.length, 0);
+    assert.deepStrictEqual(logs.map(([message]) => message), [
+      `-> HEAD ${sourceUrl}`,
+      `<- HEAD ${sourceUrl}. 200 `,
+    ]);
   });
 
   it('POSTs raw HTML to api.aem.live and does not write to da-admin', async () => {
@@ -318,7 +327,10 @@ describe('source backend routing', () => {
     assert.strictEqual(post.body, '<body><main>edited</main></body>');
     assert.strictEqual(daAdminCalls.length, 0);
     assert.strictEqual(fetchCalls.filter(({ method }) => method === 'HEAD').length, 0);
-    assert.strictEqual(logs.length, 0);
+    assert.deepStrictEqual(logs.map(([message]) => message), [
+      `-> ${sourceUrl}`,
+      `<- ${sourceUrl}. 201 `,
+    ]);
   });
 
   it('POSTs FormData to da-admin and does not write to api.aem.live for legacy sites', async () => {

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -213,19 +213,24 @@ describe('source backend routing', () => {
     });
   });
 
-  it('falls back to legacy GET when ping fails', async () => {
-    fetchResponse = async () => {
-      throw new TypeError('network failure');
-    };
-    daAdminResponse = async () => new Response('legacy image', { status: 200 });
-    const req = authedRequest('/image.png');
-    const daCtx = getDaCtx(req);
-    const { daSourceGet } = await loadRoutes();
+  [
+    new TypeError('network failure'),
+    new DOMException('timed out', 'TimeoutError'),
+  ].forEach((error) => {
+    it(`falls back to legacy GET when ping fails with ${error.name}`, async () => {
+      fetchResponse = async () => {
+        throw error;
+      };
+      daAdminResponse = async () => new Response('legacy image', { status: 200 });
+      const req = authedRequest('/image.png');
+      const daCtx = getDaCtx(req);
+      const { daSourceGet } = await loadRoutes();
 
-    const response = await daSourceGet({ req, env, daCtx });
+      const response = await daSourceGet({ req, env, daCtx });
 
-    assert.strictEqual(await response.text(), 'legacy image');
-    assert.strictEqual(daAdminCalls.length, 1);
+      assert.strictEqual(await response.text(), 'legacy image');
+      assert.strictEqual(daAdminCalls.length, 1);
+    });
   });
 
   it('HEADs a source-bus resource through api.aem.live', async () => {
@@ -314,7 +319,7 @@ describe('source backend routing', () => {
 
   [
     new TypeError('network failure'),
-    new DOMException('timed out', 'AbortError'),
+    new DOMException('timed out', 'TimeoutError'),
   ].forEach((error) => {
     it(`returns 503 without writing when POST ping fails with ${error.name}`, async () => {
       fetchResponse = async () => {
@@ -330,6 +335,27 @@ describe('source backend routing', () => {
       assert.strictEqual(fetchCalls.length, 1);
       assert.strictEqual(daAdminCalls.length, 0);
     });
+  });
+
+  it('retries after an unexpected probe error instead of caching the rejection', async () => {
+    let firstProbe = true;
+    fetchResponse = async ({ url }) => {
+      if (url === PING_URL && firstProbe) {
+        firstProbe = false;
+        throw new Error('unexpected failure');
+      }
+      if (url === PING_URL) return upgradeResponse();
+      return new Response('source image', { status: 200 });
+    };
+    const req = authedRequest('/image.png');
+    const daCtx = getDaCtx(req);
+    const { daSourceGet } = await loadRoutes();
+
+    await assert.rejects(() => daSourceGet({ req, env, daCtx }), /unexpected failure/);
+    const response = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(await response.text(), 'source image');
+    assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
   });
 
   it('refreshes the routing decision after five minutes to allow rollback', async () => {

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -367,7 +367,6 @@ describe('source backend routing', () => {
     const { daSourceGet } = await loadRoutes();
     const first = await daSourceGet({ req, env, daCtx });
     upgraded = false;
-    upgraded = false;
     const second = await daSourceGet({ req, env, daCtx });
 
     assert.strictEqual(await first.text(), 'source image');

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -36,8 +36,10 @@ function callDetails(input, init = {}) {
 
 describe('source backend routing', () => {
   let originalFetch;
+  let originalWarn;
   let fetchCalls;
   let daAdminCalls;
+  let warnings;
   let fetchResponse;
   let daAdminResponse;
   let composedBodies;
@@ -80,8 +82,10 @@ describe('source backend routing', () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    originalWarn = console.warn;
     fetchCalls = [];
     daAdminCalls = [];
+    warnings = [];
     composedBodies = [];
     fetchResponse = async () => new Response('', { status: 404 });
     daAdminResponse = async () => new Response('', { status: 404 });
@@ -91,6 +95,7 @@ describe('source backend routing', () => {
       fetchCalls.push(details);
       return fetchResponse(details);
     };
+    console.warn = (...args) => warnings.push(args);
     env = {
       DA_ADMIN,
       daadmin: {
@@ -105,6 +110,7 @@ describe('source backend routing', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
   });
 
   function upgradeResponse(upgraded = true) {
@@ -302,6 +308,7 @@ describe('source backend routing', () => {
     assert.strictEqual(post.headers.get('Content-Type'), 'text/html');
     assert.strictEqual(post.body, '<body><main>edited</main></body>');
     assert.strictEqual(daAdminCalls.length, 0);
+    assert.strictEqual(fetchCalls.filter(({ method }) => method === 'HEAD').length, 0);
   });
 
   it('POSTs FormData to da-admin and does not write to api.aem.live for legacy sites', async () => {
@@ -317,11 +324,101 @@ describe('source backend routing', () => {
     assert.strictEqual(fetchCalls.length, 1);
     assert.strictEqual(daAdminCalls.length, 1);
     assert.strictEqual(daAdminCalls[0].method, 'POST');
+    assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'HEAD').length, 0);
     const body = await daAdminCalls[0].input.clone().formData();
     assert.strictEqual(
       await body.get('data').text(),
       '<body><main>edited</main></body>',
     );
+  });
+
+  [
+    {
+      title: 'uses api.aem.live when only source bus has the document',
+      aemHead: 200,
+      daHead: 404,
+      backend: 'aem',
+    },
+    {
+      title: 'uses da-admin when only legacy DA has the document',
+      aemHead: 404,
+      daHead: 200,
+      backend: 'da',
+    },
+    {
+      title: 'uses da-admin for a new document missing from both backends',
+      aemHead: 404,
+      daHead: 404,
+      backend: 'da',
+    },
+    {
+      title: 'uses api.aem.live when both backends have the document',
+      aemHead: 200,
+      daHead: 200,
+      backend: 'aem',
+      warns: true,
+    },
+  ].forEach(({
+    title, aemHead, daHead, backend, warns,
+  }) => {
+    it(title, async () => {
+      const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+      fetchResponse = async ({ url, method }) => {
+        if (url === PING_URL) return new Response('', { status: 500 });
+        if (url === sourceUrl && method === 'HEAD') {
+          return new Response(null, { status: aemHead });
+        }
+        if (url === sourceUrl && method === 'POST') {
+          return new Response('', { status: 201 });
+        }
+        return new Response('', { status: 500 });
+      };
+      daAdminResponse = async ({ method }) => (
+        new Response(null, { status: method === 'HEAD' ? daHead : 200 })
+      );
+      const req = authedRequest('/page', { method: 'POST' });
+      const daCtx = getDaCtx(req);
+      const { daSourcePost } = await loadRoutes();
+
+      const response = await daSourcePost({ req, env, daCtx });
+
+      assert.strictEqual(response.status, backend === 'aem' ? 201 : 200);
+      assert.strictEqual(fetchCalls.filter(({ method }) => method === 'HEAD').length, 1);
+      assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'HEAD').length, 1);
+      assert.strictEqual(
+        fetchCalls.filter(({ method }) => method === 'POST').length,
+        backend === 'aem' ? 1 : 0,
+      );
+      assert.strictEqual(
+        daAdminCalls.filter(({ method }) => method === 'POST').length,
+        backend === 'da' ? 1 : 0,
+      );
+      assert.strictEqual(warnings.length, warns ? 2 : 1);
+    });
+  });
+
+  it('uses da-admin when a backend HEAD fails', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+    fetchResponse = async ({ url, method }) => {
+      if (url === PING_URL) return new Response('', { status: 500 });
+      if (url === sourceUrl && method === 'HEAD') {
+        throw new Error('Network connection lost.');
+      }
+      return new Response('', { status: 500 });
+    };
+    daAdminResponse = async ({ method }) => (
+      new Response(null, { status: method === 'HEAD' ? 200 : 200 })
+    );
+    const req = authedRequest('/page', { method: 'POST' });
+    const daCtx = getDaCtx(req);
+    const { daSourcePost } = await loadRoutes();
+
+    const response = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(fetchCalls.filter(({ method }) => method === 'POST').length, 0);
+    assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'HEAD').length, 1);
+    assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'POST').length, 1);
   });
 
   [401, 403, 404, 500].forEach((status) => {
@@ -335,10 +432,12 @@ describe('source backend routing', () => {
       const response = await daSourcePost({ req, env, daCtx });
 
       assert.strictEqual(response.status, 200);
-      assert.strictEqual(fetchCalls.length, 1);
+      assert.strictEqual(fetchCalls.length, 2);
       assert.strictEqual(fetchCalls[0].method, 'GET');
-      assert.strictEqual(daAdminCalls.length, 1);
-      assert.strictEqual(daAdminCalls[0].method, 'POST');
+      assert.strictEqual(fetchCalls[1].method, 'HEAD');
+      assert.strictEqual(daAdminCalls.length, 2);
+      assert.strictEqual(daAdminCalls[0].method, 'HEAD');
+      assert.strictEqual(daAdminCalls[1].method, 'POST');
     });
   });
 
@@ -358,10 +457,12 @@ describe('source backend routing', () => {
       const response = await daSourcePost({ req, env, daCtx });
 
       assert.strictEqual(response.status, 200);
-      assert.strictEqual(fetchCalls.length, 1);
+      assert.strictEqual(fetchCalls.length, 2);
       assert.strictEqual(fetchCalls[0].method, 'GET');
-      assert.strictEqual(daAdminCalls.length, 1);
-      assert.strictEqual(daAdminCalls[0].method, 'POST');
+      assert.strictEqual(fetchCalls[1].method, 'HEAD');
+      assert.strictEqual(daAdminCalls.length, 2);
+      assert.strictEqual(daAdminCalls[0].method, 'HEAD');
+      assert.strictEqual(daAdminCalls[1].method, 'POST');
     });
   });
 

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -356,10 +356,9 @@ describe('source backend routing', () => {
       aemHead: 200,
       daHead: 200,
       backend: 'aem',
-      warns: true,
     },
   ].forEach(({
-    title, aemHead, daHead, backend, warns,
+    title, aemHead, daHead, backend,
   }) => {
     it(title, async () => {
       const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
@@ -393,7 +392,7 @@ describe('source backend routing', () => {
         daAdminCalls.filter(({ method }) => method === 'POST').length,
         backend === 'da' ? 1 : 0,
       );
-      assert.strictEqual(warnings.length, warns ? 2 : 1);
+      assert.strictEqual(warnings.length, 0);
     });
   });
 

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -421,6 +421,34 @@ describe('source backend routing', () => {
     assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'POST').length, 1);
   });
 
+  it('uses api.aem.live when its HEAD succeeds and da-admin HEAD fails', async () => {
+    const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+    fetchResponse = async ({ url, method }) => {
+      if (url === PING_URL) return new Response('', { status: 500 });
+      if (url === sourceUrl && method === 'HEAD') {
+        return new Response(null, { status: 200 });
+      }
+      if (url === sourceUrl && method === 'POST') {
+        return new Response('', { status: 201 });
+      }
+      return new Response('', { status: 500 });
+    };
+    daAdminResponse = async ({ method }) => {
+      if (method === 'HEAD') throw new Error('Network connection lost.');
+      return new Response('', { status: 200 });
+    };
+    const req = authedRequest('/page', { method: 'POST' });
+    const daCtx = getDaCtx(req);
+    const { daSourcePost } = await loadRoutes();
+
+    const response = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(response.status, 201);
+    assert.strictEqual(fetchCalls.filter(({ method }) => method === 'POST').length, 1);
+    assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'HEAD').length, 1);
+    assert.strictEqual(daAdminCalls.filter(({ method }) => method === 'POST').length, 0);
+  });
+
   [401, 403, 404, 500].forEach((status) => {
     it(`POSTs to da-admin when ping returns ${status}`, async () => {
       fetchResponse = async () => new Response('', { status });

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -36,7 +36,6 @@ function callDetails(input, init = {}) {
 
 describe('source backend routing', () => {
   let originalFetch;
-  let originalDateNow;
   let fetchCalls;
   let daAdminCalls;
   let fetchResponse;
@@ -81,7 +80,6 @@ describe('source backend routing', () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
-    originalDateNow = Date.now;
     fetchCalls = [];
     daAdminCalls = [];
     composedBodies = [];
@@ -107,7 +105,6 @@ describe('source backend routing', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    Date.now = originalDateNow;
   });
 
   function upgradeResponse(upgraded = true) {
@@ -358,10 +355,8 @@ describe('source backend routing', () => {
     assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
   });
 
-  it('refreshes the routing decision after five minutes to allow rollback', async () => {
-    let now = 1_000;
+  it('probes before every request so routing changes apply immediately', async () => {
     let upgraded = true;
-    Date.now = () => now;
     fetchResponse = async ({ url }) => {
       if (url === PING_URL) return upgradeResponse(upgraded);
       return new Response('source image', { status: 200 });
@@ -370,10 +365,9 @@ describe('source backend routing', () => {
     const req = authedRequest('/image.png');
     const daCtx = getDaCtx(req);
     const { daSourceGet } = await loadRoutes();
-
     const first = await daSourceGet({ req, env, daCtx });
     upgraded = false;
-    now += 300_001;
+    upgraded = false;
     const second = await daSourceGet({ req, env, daCtx });
 
     assert.strictEqual(await first.text(), 'source image');
@@ -382,10 +376,8 @@ describe('source backend routing', () => {
     assert.strictEqual(daAdminCalls.length, 1);
   });
 
-  it('uses a stale routing decision when a refresh fails', async () => {
-    let now = 1_000;
+  it('does not use a stale routing decision when a later ping fails', async () => {
     let pingStatus = 200;
-    Date.now = () => now;
     fetchResponse = async ({ url }) => {
       if (url === PING_URL) {
         return pingStatus === 200
@@ -394,18 +386,40 @@ describe('source backend routing', () => {
       }
       return new Response('source image', { status: 200 });
     };
+    daAdminResponse = async () => new Response('legacy image', { status: 200 });
     const req = authedRequest('/image.png');
     const daCtx = getDaCtx(req);
     const { daSourceGet } = await loadRoutes();
 
     const first = await daSourceGet({ req, env, daCtx });
     pingStatus = 500;
-    now += 300_001;
     const second = await daSourceGet({ req, env, daCtx });
 
     assert.strictEqual(await first.text(), 'source image');
-    assert.strictEqual(await second.text(), 'source image');
+    assert.strictEqual(await second.text(), 'legacy image');
     assert.strictEqual(fetchCalls.filter(({ url }) => url === PING_URL).length, 2);
+    assert.strictEqual(daAdminCalls.length, 1);
+  });
+
+  it('probes independently for GET, HEAD, and POST', async () => {
+    fetchResponse = async ({ url, method }) => {
+      if (url === PING_URL) return upgradeResponse();
+      if (method === 'HEAD') return new Response(null, { status: 200 });
+      if (method === 'POST') return new Response('', { status: 201 });
+      return new Response('source image', { status: 200 });
+    };
+    const { daSourceGet, daSourceHead, daSourcePost } = await loadRoutes();
+    const getReq = authedRequest('/image.png');
+    const headReq = authedRequest('/image.png', { method: 'HEAD' });
+    const postReq = authedRequest('/page', { method: 'POST' });
+
+    await daSourceGet({ req: getReq, env, daCtx: getDaCtx(getReq) });
+    await daSourceHead({ env, daCtx: getDaCtx(headReq) });
+    await daSourcePost({ req: postReq, env, daCtx: getDaCtx(postReq) });
+
+    const pingCalls = fetchCalls.filter(({ url }) => url === PING_URL);
+    assert.strictEqual(pingCalls.length, 3);
+    assert.ok(pingCalls.every(({ method }) => method === 'GET'));
     assert.strictEqual(daAdminCalls.length, 0);
   });
 });

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -36,9 +36,11 @@ function callDetails(input, init = {}) {
 
 describe('source backend routing', () => {
   let originalFetch;
+  let originalLog;
   let originalWarn;
   let fetchCalls;
   let daAdminCalls;
+  let logs;
   let warnings;
   let fetchResponse;
   let daAdminResponse;
@@ -82,9 +84,11 @@ describe('source backend routing', () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    originalLog = console.log;
     originalWarn = console.warn;
     fetchCalls = [];
     daAdminCalls = [];
+    logs = [];
     warnings = [];
     composedBodies = [];
     fetchResponse = async () => new Response('', { status: 404 });
@@ -95,6 +99,7 @@ describe('source backend routing', () => {
       fetchCalls.push(details);
       return fetchResponse(details);
     };
+    console.log = (...args) => logs.push(args);
     console.warn = (...args) => warnings.push(args);
     env = {
       DA_ADMIN,
@@ -110,6 +115,7 @@ describe('source backend routing', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    console.log = originalLog;
     console.warn = originalWarn;
   });
 
@@ -141,6 +147,7 @@ describe('source backend routing', () => {
     assert.strictEqual(fetchCalls[0].headers.get('Authorization'), null);
     assert.strictEqual(fetchCalls[1].url, sourceUrl);
     assert.strictEqual(fetchCalls[1].headers.get('Authorization'), AUTH);
+    assert.strictEqual(logs.length, 0);
   });
 
   it('composes source-bus HTML through the existing preview pipeline', async () => {
@@ -162,6 +169,7 @@ describe('source backend routing', () => {
     assert.deepStrictEqual(composedBodies, ['<body><main>source page</main></body>']);
     assert.strictEqual(await response.text(), '<html><body><main>source page</main></body></html>');
     assert.strictEqual(daAdminCalls.length, 0);
+    assert.strictEqual(logs.length, 0);
   });
 
   [401, 403, 500, 503].forEach((status) => {
@@ -285,6 +293,7 @@ describe('source backend routing', () => {
     assert.strictEqual(response.headers.get('Content-Length'), '42');
     assert.deepStrictEqual(fetchCalls.map(({ method }) => method), ['GET', 'HEAD']);
     assert.strictEqual(daAdminCalls.length, 0);
+    assert.strictEqual(logs.length, 0);
   });
 
   it('POSTs raw HTML to api.aem.live and does not write to da-admin', async () => {
@@ -309,6 +318,7 @@ describe('source backend routing', () => {
     assert.strictEqual(post.body, '<body><main>edited</main></body>');
     assert.strictEqual(daAdminCalls.length, 0);
     assert.strictEqual(fetchCalls.filter(({ method }) => method === 'HEAD').length, 0);
+    assert.strictEqual(logs.length, 0);
   });
 
   it('POSTs FormData to da-admin and does not write to api.aem.live for legacy sites', async () => {

--- a/test/routes/source-routing.test.js
+++ b/test/routes/source-routing.test.js
@@ -158,6 +158,32 @@ describe('source backend routing', () => {
     assert.strictEqual(daAdminCalls.length, 0);
   });
 
+  [401, 403, 500, 503].forEach((status) => {
+    it(`returns source-bus HTML status ${status} without composing a page`, async () => {
+      const sourceUrl = `${AEM_API}/${ORG}/sites/${SITE}/source/page.html`;
+      fetchResponse = async ({ url }) => {
+        if (url === PING_URL) return upgradeResponse();
+        if (url === sourceUrl) {
+          return new Response('source failed', {
+            status,
+            headers: { 'X-Error': 'source failed' },
+          });
+        }
+        return new Response('', { status: 500 });
+      };
+      const req = authedRequest('/page');
+      const daCtx = getDaCtx(req);
+      const { daSourceGet } = await loadRoutes();
+
+      const response = await daSourceGet({ req, env, daCtx });
+
+      assert.strictEqual(response.status, status);
+      assert.strictEqual(response.headers.get('X-Error'), 'source failed');
+      assert.strictEqual(await response.text(), 'source failed');
+      assert.deepStrictEqual(composedBodies, []);
+    });
+  });
+
   it('does not fall back to legacy content when a source-bus resource is missing', async () => {
     fetchResponse = async ({ url }) => (
       url === PING_URL ? upgradeResponse() : new Response('', { status: 404 })


### PR DESCRIPTION
## Description

This change routes source GET, HEAD, and POST requests to `api.aem.live` for source-bus sites.
Legacy sites continue through the da-admin service binding.

Each source operation sends an unauthenticated `GET` to `admin.hlx.page/ping/{org}/{site}`.
The `x-api-upgrade-available: true` header selects the source bus.
The worker does not cache the result.
[helix-admin#3687](https://github.com/adobe/helix-admin/pull/3687) sets this header for source-bus sites.
It checks whether `content.source.url` starts with `https://api.aem.live/`.
[helix-admin#3689](https://github.com/adobe/helix-admin/pull/3689) added the `/ping` route.

If the probe fails, reads use da-admin.
If the probe fails before a write, the worker sends parallel HEAD requests to both backends.
The backend that answers 200 wins.
Two 404 responses select da-admin for a new page.
Two 200 responses select `api.aem.live` and log a warning.
A rejected HEAD request selects da-admin.

Legacy sites are the majority and do not need `admin.hlx.page`.
Failing them closed on a ping error would cause the larger outage.

Source responses with 401, 403, or 5xx pass through unchanged.
Only 404 uses the new-page template.

## Related Issue

- Unblocks [adobe/da-live#1066](https://github.com/adobe/da-live/pull/1066).
- Uses [helix-admin#3687](https://github.com/adobe/helix-admin/pull/3687) and [helix-admin#3689](https://github.com/adobe/helix-admin/pull/3689).

## Motivation and Context

Helix 6 stores media in the source bus until preview.
The preview proxy had no source-bus read path, so source-bus media returned 404.
DA Live uses the preview domain to keep IMS credentials out of page scripts.

## Known limits

- Each source request adds a `/ping` round trip.
- Measured from Frankfurt: 0.483s, 0.498s, 0.519s.
- The response has `cache-control: no-store, private, must-revalidate`, so CDN caching does not help.
- The endpoint advertises `x-ratelimit-limit: 10`.
- Source-bus sites still load site config from da-admin through `getSiteConfig`.
- An unlikely DA to hlx6 source change between a GET and its POST is not handled in this PR. Closing that race needs coordinated conditional-write support across `da-live`, `da-admin`, and this worker.

## How Has This Been Tested?

- Unit: 236 tests pass, and `npm run lint` reports no errors.
- Before on `main`: the preview image request returned 404 with 398 bytes.
- After on `hlx6-ping`: local preview returned 200 with 3,669,975 bytes.
- The local payload matched the direct source response by SHA-256.
- `admin.hlx.page/ping/benpeter/hlx6-test` returned 200 with `x-api-upgrade-available: true`.
- Authenticated source GET for `benpeter/hlx6-test/index.html` returned 200 with 150 bytes.

## Screenshots

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a documentation change.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
