### PR TITLE
fix: Support apps behind Helix authentication via preview proxy

### DIFF
--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -23,7 +23,7 @@ export default async function getHandler({ req, env, daCtx }) {
 
   if (path.startsWith('/gimme_cookie')) return getCookie({ req, daCtx });
 
-  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
+  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html|html)$/i;
   if (resourceRegex.test(path)) {
     return handleAEMProxyRequest({ req, env, daCtx });
   }

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -29,7 +29,7 @@ export default async function headHandler({ req, env, daCtx }) {
   if (path.startsWith('/favicon.ico')) return head404();
   if (path.startsWith('/robots.txt')) return getRobots();
 
-  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html)$/i;
+  const resourceRegex = /\.(css|js|js\.map|json|xml|woff|woff2|otf|ttf|plain\.html|html)$/i;
   if (resourceRegex.test(path)) {
     return aemHead({ req, env, daCtx });
   }

--- a/test/handlers/get.test.js
+++ b/test/handlers/get.test.js
@@ -129,6 +129,17 @@ describe('GET handler', () => {
       assert.strictEqual(res.status, 200);
       assert.strictEqual(await res.text(), 'proxied-resource');
     });
+
+    it('proxies to AEM for explicit .html', async () => {
+      const req = new Request('https://main--site--org.preview.da.live/folder/content.html');
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await getHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), 'proxied-resource');
+    });
   });
 
   describe('assets', () => {

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -110,6 +110,18 @@ describe('HEAD handler', () => {
       assert.strictEqual(await res.text(), '');
       assert.strictEqual(aemProxyCallCount, 1);
     });
+
+    it('proxies to AEM for explicit .html and returns no body', async () => {
+      const req = new Request('https://main--site--org.preview.da.live/folder/content.html', { method: 'HEAD' });
+      const daCtx = getDaCtx(req);
+      const env = {};
+
+      const res = await headHandler({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(await res.text(), '');
+      assert.strictEqual(aemProxyCallCount, 1);
+    });
   });
 
   describe('assets', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Load `.html` resources directly from AEM, as they have no corresponding content in DA>

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

1. For a proper full proxy behaviour
2. For allowing the preview proxy to be used for authenticated apps in DA

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TODO: E2E Test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
