### PR TITLE
fix: consolidate daCtx and its usage

### DIFF
--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -43,6 +43,10 @@ export function get401(message = DEFAULT_UNAUTHORIZED_HTML_MESSAGE) {
   return daResp({ body: message, status: 401, contentType: 'text/html' });
 }
 
+export function get415(message = '') {
+  return daResp({ body: message, status: 415, contentType: 'text/html' });
+}
+
 export function head401() {
   return new Response(null, { status: 401 });
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -194,8 +194,15 @@ export async function daSourceHead({ env, daCtx }) {
 
 export async function daSourcePost({ req, env, daCtx }) {
   const {
-    org, site, sourcePath, authToken,
+    org, site, sourcePath, ext, authToken,
   } = daCtx;
+
+  // the body is rewritten as HTML below, so anything but an HTML document would be
+  // written back mangled onto the key GET reads
+  if (ext !== 'html') {
+    console.log(`415 POST ${sourcePath}, not an HTML document`);
+    return get415();
+  }
 
   const obj = await putHelper(req, env, daCtx);
   if (obj && obj.data) {

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -28,9 +28,20 @@ import { BRANCH_NOT_FOUND_HTML_MESSAGE, DEFAULT_HTML_TEMPLATE, UNAUTHORIZED_HTML
 import { getSiteConfig } from '../storage/config.js';
 import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
-// file content types accepted on an HTML POST. formData() reports octet-stream or
-// text/plain for a part whose type the client left unset, so both stay allowed.
-const HTML_POST_TYPES = ['text/html', 'text/plain', 'application/octet-stream'];
+const HTML_POST_TYPE = 'text/html';
+
+/**
+ * Whether a multipart part's type may go through the HTML serializer. Anything else
+ * would be read with `.text()` and written back mangled, so it is refused.
+ * An empty type is what workerd reports when the client declared none, and is allowed.
+ *
+ * @param {string} type The part's content type
+ * @returns {boolean}
+ */
+export function isHtmlPostType(type) {
+  if (!type) return true;
+  return type.split(';')[0].trim().toLowerCase() === HTML_POST_TYPE;
+}
 
 async function getFileBody(data) {
   const text = await data.text();
@@ -189,7 +200,7 @@ export async function daSourcePost({ req, env, daCtx }) {
   const obj = await putHelper(req, env, daCtx);
   if (obj && obj.data) {
     const isFile = obj.data instanceof File;
-    if (isFile && obj.data.type && !HTML_POST_TYPES.includes(obj.data.type)) {
+    if (isFile && !isHtmlPostType(obj.data.type)) {
       return get415();
     }
     const { body: bodyHtml } = isFile

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -35,6 +35,10 @@ export function isHtmlPostType(type) {
   return type.split(';')[0].trim().toLowerCase() === HTML_POST_TYPE;
 }
 
+function getSourceUrl(env, { org, site, sourcePath }) {
+  return new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
+}
+
 async function getFileBody(data) {
   const text = await data.text();
   return { body: text, type: data.type };
@@ -77,9 +81,7 @@ async function getPageTemplate(env, daCtx, aemCtx) {
 }
 
 export async function daSourceGet({ req, env, daCtx }) {
-  const {
-    org, site, sourcePath, ext, authToken,
-  } = daCtx;
+  const { ext, authToken } = daCtx;
 
   // check if Authorization header is present
   if (!authToken) {
@@ -99,7 +101,7 @@ export async function daSourceGet({ req, env, daCtx }) {
 
   if (ext !== 'html') {
     // for non-HTML files, simply proxy the request without processing
-    const adminUrl = new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
+    const adminUrl = getSourceUrl(env, daCtx);
     console.log(`-> ${adminUrl.toString()}`);
     const response = await env.daadmin.fetch(adminUrl, { method: 'GET', headers });
     console.log(`<- ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
@@ -119,10 +121,7 @@ export async function daSourceGet({ req, env, daCtx }) {
   }
 
   // get the content from DA admin
-  const adminUrl = new URL(
-    `/source/${org}/${site}${sourcePath}`,
-    env.DA_ADMIN,
-  );
+  const adminUrl = getSourceUrl(env, daCtx);
 
   // eslint-disable-next-line no-param-reassign
   req = new Request(adminUrl, {
@@ -166,9 +165,7 @@ export async function daSourceGet({ req, env, daCtx }) {
 }
 
 export async function daSourceHead({ env, daCtx }) {
-  const {
-    org, site, sourcePath, authToken,
-  } = daCtx;
+  const { authToken } = daCtx;
 
   if (!authToken) {
     return head401();
@@ -177,7 +174,7 @@ export async function daSourceHead({ env, daCtx }) {
   const headers = new Headers();
   headers.set('Authorization', authToken);
 
-  const adminUrl = new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
+  const adminUrl = getSourceUrl(env, daCtx);
   console.log(`-> HEAD ${adminUrl.toString()}`);
   const response = await env.daadmin.fetch(adminUrl, { method: 'HEAD', headers });
   console.log(`<- HEAD ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
@@ -185,9 +182,7 @@ export async function daSourceHead({ env, daCtx }) {
 }
 
 export async function daSourcePost({ req, env, daCtx }) {
-  const {
-    org, site, sourcePath, ext, authToken,
-  } = daCtx;
+  const { sourcePath, ext, authToken } = daCtx;
 
   // the body is rewritten as HTML below, so anything but an HTML document would be
   // written back mangled onto the key GET reads
@@ -224,10 +219,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     const data = new Blob([bodyContent], { type: 'text/html' });
     body.set('data', data);
     const headers = { Authorization: authToken };
-    const adminUrl = new URL(
-      `/source/${org}/${site}${sourcePath}`,
-      env.DA_ADMIN,
-    );
+    const adminUrl = getSourceUrl(env, daCtx);
     // eslint-disable-next-line no-param-reassign
     req = new Request(adminUrl, {
       method: 'POST',

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -22,11 +22,15 @@ import {
   applyQuickEditToDocument, buildQuickEditCookie, buildQuickEditNotFoundResponse,
 } from '../utils/quick-edit.js';
 import {
-  daResp, get401, get404, head401,
+  daResp, get401, get404, get415, head401,
 } from '../responses/index.js';
 import { BRANCH_NOT_FOUND_HTML_MESSAGE, DEFAULT_HTML_TEMPLATE, UNAUTHORIZED_HTML_MESSAGE } from '../utils/constants.js';
 import { getSiteConfig } from '../storage/config.js';
 import { restoreAbsoluteImages } from '../render/rewrite-images.js';
+
+// file content types accepted on an HTML POST. formData() reports octet-stream or
+// text/plain for a part whose type the client left unset, so both stay allowed.
+const HTML_POST_TYPES = ['text/html', 'text/plain', 'application/octet-stream'];
 
 async function getFileBody(data) {
   const text = await data.text();
@@ -71,7 +75,7 @@ async function getPageTemplate(env, daCtx, aemCtx) {
 
 export async function daSourceGet({ req, env, daCtx }) {
   const {
-    org, site, path, ext, authToken,
+    org, site, sourcePath, ext, authToken,
   } = daCtx;
 
   // check if Authorization header is present
@@ -91,11 +95,8 @@ export async function daSourceGet({ req, env, daCtx }) {
   headers.set('Authorization', authToken);
 
   if (ext !== 'html') {
-    /*
-     for non-HTML files, simply proxy the request without processing
-     and ensure that extensions are not duplicated
-    */
-    const adminUrl = new URL(`/source/${org}/${site}${path}`, env.DA_ADMIN);
+    // for non-HTML files, simply proxy the request without processing
+    const adminUrl = new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
     console.log(`-> ${adminUrl.toString()}`);
     const response = await env.daadmin.fetch(adminUrl, { method: 'GET', headers });
     console.log(`<- ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
@@ -116,7 +117,7 @@ export async function daSourceGet({ req, env, daCtx }) {
 
   // get the content from DA admin
   const adminUrl = new URL(
-    `/source/${org}/${site}${path}.${ext}`,
+    `/source/${org}/${site}${sourcePath}`,
     env.DA_ADMIN,
   );
 
@@ -163,7 +164,7 @@ export async function daSourceGet({ req, env, daCtx }) {
 
 export async function daSourceHead({ env, daCtx }) {
   const {
-    org, site, path, ext, authToken,
+    org, site, sourcePath, authToken,
   } = daCtx;
 
   if (!authToken) {
@@ -173,8 +174,7 @@ export async function daSourceHead({ env, daCtx }) {
   const headers = new Headers();
   headers.set('Authorization', authToken);
 
-  const adminPath = ext !== 'html' ? path : `${path}.${ext}`;
-  const adminUrl = new URL(`/source/${org}/${site}${adminPath}`, env.DA_ADMIN);
+  const adminUrl = new URL(`/source/${org}/${site}${sourcePath}`, env.DA_ADMIN);
   console.log(`-> HEAD ${adminUrl.toString()}`);
   const response = await env.daadmin.fetch(adminUrl, { method: 'HEAD', headers });
   console.log(`<- HEAD ${adminUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
@@ -183,12 +183,15 @@ export async function daSourceHead({ env, daCtx }) {
 
 export async function daSourcePost({ req, env, daCtx }) {
   const {
-    org, site, path, ext, authToken,
+    org, site, sourcePath, authToken,
   } = daCtx;
 
   const obj = await putHelper(req, env, daCtx);
   if (obj && obj.data) {
     const isFile = obj.data instanceof File;
+    if (isFile && obj.data.type && !HTML_POST_TYPES.includes(obj.data.type)) {
+      return get415();
+    }
     const { body: bodyHtml } = isFile
       ? await getFileBody(obj.data)
       : getTextBody(obj.data);
@@ -212,7 +215,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     body.set('data', data);
     const headers = { Authorization: authToken };
     const adminUrl = new URL(
-      `/source/${org}/${site}${path}.${ext}`,
+      `/source/${org}/${site}${sourcePath}`,
       env.DA_ADMIN,
     );
     // eslint-disable-next-line no-param-reassign
@@ -227,5 +230,5 @@ export async function daSourcePost({ req, env, daCtx }) {
     return response;
   }
 
-  return undefined;
+  return get415();
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -30,14 +30,6 @@ import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
 const HTML_POST_TYPE = 'text/html';
 
-/**
- * Whether a multipart part's type may go through the HTML serializer. Anything else
- * would be read with `.text()` and written back mangled, so it is refused.
- * An empty type is what workerd reports when the client declared none, and is allowed.
- *
- * @param {string} type The part's content type
- * @returns {boolean}
- */
 export function isHtmlPostType(type) {
   if (!type) return true;
   return type.split(';')[0].trim().toLowerCase() === HTML_POST_TYPE;

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -73,8 +73,10 @@ function getSiteToken(req) {
 
 /**
  * Gets Dark Alley Context
- * @param {pathname} pathname
- * @returns {DaCtx} The Dark Alley Context.
+ * @param {Request} req The incoming request.
+ * @returns {Object} The Dark Alley Context, where `path` is the request pathname
+ * (minus the `/org/site` prefix on localhost), `aemPathname` is the path requested
+ * from `*.aem.page`, and `sourcePath` is the path requested from the store.
  */
 export function getDaCtx(req) {
   const { pathname, hostname, searchParams } = new URL(req.url);
@@ -98,33 +100,15 @@ export function getDaCtx(req) {
 
   // Sanitize the remaining path parts
   const pathParts = parts.filter((part) => part !== '');
-  const keyBase = `${site}/${pathParts.join('/')}`;
 
-  // Get the final source name
-  daCtx.filename = pathParts.pop() || '';
-
-  // Handle folders and files under a site
-  const split = daCtx.filename.split('.');
-
-  // DA Content - Add HTML if there is only one part to the split
-  if (split.length === 1) split.push('html');
-  daCtx.isFile = split.length > 1;
-  if (daCtx.isFile) daCtx.ext = split.pop();
-  daCtx.name = split.join('.');
-
-  // Set keys
-  daCtx.key = daCtx?.ext === 'html' ? `${keyBase}.html` : keyBase;
-  daCtx.propsKey = `${daCtx.key}.props`;
+  // Get the final source name and its extension
+  const filename = pathParts.pop() || '';
+  const dotted = filename.includes('.');
+  daCtx.ext = dotted ? filename.split('.').pop() : 'html';
 
   // Set paths for API consumption
   daCtx.aemPathname = path.endsWith('/index') ? path.substring(0, path.length - 5) : path;
-  const daPathBase = [...pathParts, daCtx.name].join('/');
-
-  if (!daCtx.ext || (!daCtx.name.includes('plain') && daCtx.ext === 'html')) {
-    daCtx.pathname = `/${daPathBase}`;
-  } else {
-    daCtx.pathname = `/${daPathBase}.${daCtx.ext}`;
-  }
+  daCtx.sourcePath = `/${[...pathParts, dotted ? filename : `${filename}.html`].join('/')}`;
 
   const query = Object.fromEntries(searchParams.entries());
   if (typeof query['ue-service'] === 'string') {

--- a/src/utils/daCtx.js
+++ b/src/utils/daCtx.js
@@ -110,10 +110,8 @@ export function getDaCtx(req) {
   daCtx.aemPathname = path.endsWith('/index') ? path.substring(0, path.length - 5) : path;
   daCtx.sourcePath = `/${[...pathParts, dotted ? filename : `${filename}.html`].join('/')}`;
 
-  const query = Object.fromEntries(searchParams.entries());
-  if (typeof query['ue-service'] === 'string') {
-    daCtx.ueService = query['ue-service'];
-  }
+  const ueService = searchParams.get('ue-service');
+  if (ueService !== null) daCtx.ueService = ueService;
 
   daCtx.authToken = getAuthToken(req);
   daCtx.siteToken = getSiteToken(req);

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -375,4 +375,44 @@ describe('daSourcePost', () => {
     assert.ok(res instanceof Response);
     assert.deepStrictEqual(fetched, []);
   });
+
+  ['text/html; charset=utf-8', 'text/html;charset=UTF-8', 'TEXT/HTML', 'text/HTML '].forEach((type) => {
+    it(`writes an HTML File declared as "${type}"`, async () => {
+      const { env, fetched } = recorder();
+      const html = new File(['<body>hello</body>'], 'page.html', { type });
+      const req = formReq('https://main--site--org.ue.da.live/page', html);
+      const daCtx = getDaCtx(req);
+
+      const res = await daSourcePost({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 200);
+      assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+    });
+  });
+
+  ['application/octet-stream', 'text/plain', 'image/svg+xml', 'application/pdf'].forEach((type) => {
+    it(`refuses a File declared as "${type}"`, async () => {
+      const { env, fetched } = recorder();
+      const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'logo.png', { type });
+      const req = formReq('https://main--site--org.ue.da.live/media/logo.png', file);
+      const daCtx = getDaCtx(req);
+
+      const res = await daSourcePost({ req, env, daCtx });
+
+      assert.strictEqual(res.status, 415);
+      assert.deepStrictEqual(fetched, []);
+    });
+  });
+
+  it('writes a File with no declared type', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'page.html');
+    const req = formReq('https://main--site--org.ue.da.live/page', html);
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
 });

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -16,7 +16,45 @@ import esmock from 'esmock';
 import reqs from '../mocks/req.js';
 
 const { getDaCtx } = await import('../../src/utils/daCtx.js');
-const { daSourceHead } = await import('../../src/routes/da-admin.js');
+const { daSourceHead, daSourcePost } = await import('../../src/routes/da-admin.js');
+
+const authedReq = (url) => new Request(url, { headers: { Authorization: 'Bearer t' } });
+
+const formReq = (url, data) => {
+  const body = new FormData();
+  body.set('data', data);
+  return new Request(url, { method: 'POST', body, headers: { Authorization: 'Bearer t' } });
+};
+
+// records every URL handed to env.daadmin.fetch, whether it is called with a
+// URL (GET non-HTML, HEAD) or with a Request (GET HTML, POST)
+const recorder = () => {
+  const fetched = [];
+  const env = {
+    DA_ADMIN: 'https://admin.da.live',
+    daadmin: {
+      fetch: async (input) => {
+        fetched.push(input instanceof Request ? input.url : input.href);
+        return new Response('<body>stored</body>', { status: 200 });
+      },
+    },
+  };
+  return { env, fetched };
+};
+
+const mockRoutes = async () => esmock('../../src/routes/da-admin.js', {
+  '../../src/utils/aemCtx.js': {
+    getAemCtx: () => ({}),
+    getAEMHtml: async () => '<meta name="from" content="aem" />',
+  },
+  '../../src/render/compose.js': {
+    composeHtml: async () => ({ tree: true }),
+    serializeHtml: () => '<html>composed</html>',
+  },
+  '../../src/ue/ue.js': {
+    applyUEInstrumentation: async () => {},
+  },
+});
 
 describe('daSourceHead', () => {
   describe('when no authToken is present', () => {
@@ -44,8 +82,6 @@ describe('daSourceGet', () => {
     DA_ADMIN: 'https://admin.da.live',
     daadmin: { fetch: async () => new Response('<body>stored</body>', { status: 200 }) },
   };
-
-  const authedReq = (url) => new Request(url, { headers: { Authorization: 'Bearer t' } });
 
   // record which composition / instrumentation calls happen and with what
   let calls;
@@ -201,5 +237,142 @@ describe('daSourceGet', () => {
     assert.strictEqual(calls.ue, 0);
     const html = await res.text();
     assert.ok(html.includes('Unable to retrieve AEM branch'));
+  });
+});
+
+describe('source URLs', () => {
+  it('GET / reads /index.html', async () => {
+    const { daSourceGet } = await mockRoutes();
+    const { env, fetched } = recorder();
+    const req = authedReq('https://main--site--org.ue.da.live/');
+    const daCtx = getDaCtx(req);
+
+    await daSourceGet({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/index.html']);
+  });
+
+  it('GET /page.html reads /page.html', async () => {
+    const { daSourceGet } = await mockRoutes();
+    const { env, fetched } = recorder();
+    const req = authedReq('https://main--site--org.ue.da.live/page.html');
+    const daCtx = getDaCtx(req);
+
+    await daSourceGet({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
+
+  it('GET /Media/Logo.PNG reads /media/logo.png', async () => {
+    const { daSourceGet } = await mockRoutes();
+    const { env, fetched } = recorder();
+    const req = authedReq('https://main--site--org.ue.da.live/Media/Logo.PNG');
+    const daCtx = getDaCtx(req);
+
+    await daSourceGet({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/media/logo.png']);
+  });
+
+  it('HEAD / reads /index.html', async () => {
+    const { env, fetched } = recorder();
+    const daCtx = getDaCtx(authedReq('https://main--site--org.ue.da.live/'));
+
+    await daSourceHead({ env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/index.html']);
+  });
+
+  it('HEAD /page.html reads /page.html', async () => {
+    const { env, fetched } = recorder();
+    const daCtx = getDaCtx(authedReq('https://main--site--org.ue.da.live/page.html'));
+
+    await daSourceHead({ env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
+
+  it('HEAD /Media/Logo.PNG reads /media/logo.png', async () => {
+    const { env, fetched } = recorder();
+    const daCtx = getDaCtx(authedReq('https://main--site--org.ue.da.live/Media/Logo.PNG'));
+
+    await daSourceHead({ env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/media/logo.png']);
+  });
+
+  it('POST / writes /index.html', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'index.html', { type: 'text/html' });
+    const req = formReq('https://main--site--org.ue.da.live/', html);
+    const daCtx = getDaCtx(req);
+
+    await daSourcePost({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/index.html']);
+  });
+
+  it('POST /page.html writes /page.html', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'page.html', { type: 'text/html' });
+    const req = formReq('https://main--site--org.ue.da.live/page.html', html);
+    const daCtx = getDaCtx(req);
+
+    await daSourcePost({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
+
+  it('POST /Media/Logo.PNG writes /media/logo.png', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'logo.html', { type: 'text/html' });
+    const req = formReq('https://main--site--org.ue.da.live/Media/Logo.PNG', html);
+    const daCtx = getDaCtx(req);
+
+    await daSourcePost({ req, env, daCtx });
+
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/media/logo.png']);
+  });
+});
+
+describe('daSourcePost', () => {
+  it('refuses a binary File with 415 and does not write', async () => {
+    const { env, fetched } = recorder();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const png = new File([bytes], 'logo.png', { type: 'image/png' });
+    const req = formReq('https://main--site--org.ue.da.live/media/logo.png', png);
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 415);
+    assert.deepStrictEqual(fetched, []);
+  });
+
+  it('writes an HTML File', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'page.html', { type: 'text/html' });
+    const req = formReq('https://main--site--org.ue.da.live/Page', html);
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
+
+  it('returns a response when the content type is not a form type', async () => {
+    const { env, fetched } = recorder();
+    const req = new Request('https://main--site--org.ue.da.live/page', {
+      method: 'POST',
+      body: '{}',
+      headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+    });
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.ok(res instanceof Response);
+    assert.deepStrictEqual(fetched, []);
   });
 });

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -369,11 +369,13 @@ describe('daSourcePost to a non-HTML path', () => {
 });
 
 describe('daSourcePost', () => {
+  // on an HTML path, so the path check does not answer first and this exercises
+  // the part-type check
   it('refuses a binary File with 415 and does not write', async () => {
     const { env, fetched } = recorder();
     const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     const png = new File([bytes], 'logo.png', { type: 'image/png' });
-    const req = formReq('https://main--site--org.ue.da.live/media/logo.png', png);
+    const req = formReq('https://main--site--org.ue.da.live/page', png);
     const daCtx = getDaCtx(req);
 
     const res = await daSourcePost({ req, env, daCtx });
@@ -394,7 +396,22 @@ describe('daSourcePost', () => {
     assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
   });
 
-  it('returns a response when the content type is not a form type', async () => {
+  it('writes a string part', async () => {
+    const { env, fetched } = recorder();
+    const req = new Request('https://main--site--org.ue.da.live/page', {
+      method: 'POST',
+      body: new URLSearchParams({ data: '<body>hello</body>' }),
+      headers: { Authorization: 'Bearer t' },
+    });
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  });
+
+  it('refuses 415 with an empty body when the request content type is not a form type', async () => {
     const { env, fetched } = recorder();
     const req = new Request('https://main--site--org.ue.da.live/page', {
       method: 'POST',
@@ -405,36 +422,35 @@ describe('daSourcePost', () => {
 
     const res = await daSourcePost({ req, env, daCtx });
 
-    assert.ok(res instanceof Response);
+    assert.strictEqual(res.status, 415);
+    assert.strictEqual(await res.text(), '');
     assert.deepStrictEqual(fetched, []);
   });
 
-  ['text/html; charset=utf-8', 'text/html;charset=UTF-8', 'TEXT/HTML', 'text/HTML '].forEach((type) => {
-    it(`writes an HTML File declared as "${type}"`, async () => {
-      const { env, fetched } = recorder();
-      const html = new File(['<body>hello</body>'], 'page.html', { type });
-      const req = formReq('https://main--site--org.ue.da.live/page', html);
-      const daCtx = getDaCtx(req);
+  // the full normalization matrix is under isHtmlPostType; these two prove it is
+  // wired into the route. the charset form is what da-admin itself sends back.
+  it('writes an HTML File declared with a charset', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'page.html', { type: 'text/html; charset=utf-8' });
+    const req = formReq('https://main--site--org.ue.da.live/page', html);
+    const daCtx = getDaCtx(req);
 
-      const res = await daSourcePost({ req, env, daCtx });
+    const res = await daSourcePost({ req, env, daCtx });
 
-      assert.strictEqual(res.status, 200);
-      assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
-    });
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
   });
 
-  ['application/octet-stream', 'text/plain', 'image/svg+xml', 'application/pdf'].forEach((type) => {
-    it(`refuses a File declared as "${type}"`, async () => {
-      const { env, fetched } = recorder();
-      const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'logo.png', { type });
-      const req = formReq('https://main--site--org.ue.da.live/media/logo.png', file);
-      const daCtx = getDaCtx(req);
+  it('refuses a File declared as application/octet-stream on an HTML path', async () => {
+    const { env, fetched } = recorder();
+    const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'logo.png', { type: 'application/octet-stream' });
+    const req = formReq('https://main--site--org.ue.da.live/page', file);
+    const daCtx = getDaCtx(req);
 
-      const res = await daSourcePost({ req, env, daCtx });
+    const res = await daSourcePost({ req, env, daCtx });
 
-      assert.strictEqual(res.status, 415);
-      assert.deepStrictEqual(fetched, []);
-    });
+    assert.strictEqual(res.status, 415);
+    assert.deepStrictEqual(fetched, []);
   });
 });
 

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -16,7 +16,7 @@ import esmock from 'esmock';
 import reqs from '../mocks/req.js';
 
 const { getDaCtx } = await import('../../src/utils/daCtx.js');
-const { daSourceHead, daSourcePost } = await import('../../src/routes/da-admin.js');
+const { daSourceHead, daSourcePost, isHtmlPostType } = await import('../../src/routes/da-admin.js');
 
 const authedReq = (url) => new Request(url, { headers: { Authorization: 'Bearer t' } });
 
@@ -403,16 +403,22 @@ describe('daSourcePost', () => {
       assert.deepStrictEqual(fetched, []);
     });
   });
+});
 
-  it('writes a File with no declared type', async () => {
-    const { env, fetched } = recorder();
-    const html = new File(['<body>hello</body>'], 'page.html');
-    const req = formReq('https://main--site--org.ue.da.live/page', html);
-    const daCtx = getDaCtx(req);
+// workerd and undici disagree on File.type for a multipart part, so the rule is
+// asserted directly. measured in workerd 4.118.0: an absent part Content-Type
+// reports '', and a declared one is preserved verbatim including its case and
+// parameters. undici substitutes application/octet-stream and lowercases.
+describe('isHtmlPostType', () => {
+  ['', 'text/html', 'text/html; charset=utf-8', 'text/html;charset=UTF-8', 'TEXT/HTML', 'text/HTML '].forEach((type) => {
+    it(`accepts ${JSON.stringify(type)}`, () => {
+      assert.strictEqual(isHtmlPostType(type), true);
+    });
+  });
 
-    const res = await daSourcePost({ req, env, daCtx });
-
-    assert.strictEqual(res.status, 200);
-    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
+  ['application/octet-stream', 'text/plain', 'image/png', 'image/svg+xml', 'application/pdf', 'application/json'].forEach((type) => {
+    it(`rejects ${JSON.stringify(type)}`, () => {
+      assert.strictEqual(isHtmlPostType(type), false);
+    });
   });
 });

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -322,16 +322,49 @@ describe('source URLs', () => {
 
     assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/page.html']);
   });
+});
 
-  it('POST /Media/Logo.PNG writes /media/logo.png', async () => {
+// the HTML serializer would rewrite whatever it is given, so a POST is refused
+// unless it addresses an HTML document. sourcePath ends `.html` iff ext is html,
+// so this covers every non-HTML target.
+describe('daSourcePost to a non-HTML path', () => {
+  it('refuses an HTML File and does not write', async () => {
     const { env, fetched } = recorder();
     const html = new File(['<body>hello</body>'], 'logo.html', { type: 'text/html' });
     const req = formReq('https://main--site--org.ue.da.live/Media/Logo.PNG', html);
     const daCtx = getDaCtx(req);
 
-    await daSourcePost({ req, env, daCtx });
+    const res = await daSourcePost({ req, env, daCtx });
 
-    assert.deepStrictEqual(fetched, ['https://admin.da.live/source/org/site/media/logo.png']);
+    assert.strictEqual(res.status, 415);
+    assert.deepStrictEqual(fetched, []);
+  });
+
+  // an untyped part is the case the part-type check cannot cover in node, since
+  // undici substitutes application/octet-stream where workerd reports ''. The path
+  // check catches it either way, so this is asserted on a string part, which
+  // carries no type in either runtime.
+  it('refuses a string part, which carries no type at all, and does not write', async () => {
+    const { env, fetched } = recorder();
+    const req = formReq('https://main--site--org.ue.da.live/media/logo.png', '<body>hello</body>');
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 415);
+    assert.deepStrictEqual(fetched, []);
+  });
+
+  it('refuses a POST to a json path', async () => {
+    const { env, fetched } = recorder();
+    const html = new File(['<body>hello</body>'], 'sheet.html', { type: 'text/html' });
+    const req = formReq('https://main--site--org.ue.da.live/sheet.json', html);
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourcePost({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 415);
+    assert.deepStrictEqual(fetched, []);
   });
 });
 

--- a/test/utils/daCtx.test.js
+++ b/test/utils/daCtx.test.js
@@ -41,7 +41,7 @@ describe('DA context', () => {
     });
 
     it('should return the correct path names', () => {
-      assert.strictEqual(daCtx.pathname, '/folder/content');
+      assert.strictEqual(daCtx.sourcePath, '/folder/content.html');
       assert.strictEqual(daCtx.aemPathname, '/folder/content');
     });
 
@@ -68,7 +68,7 @@ describe('DA context', () => {
     });
 
     it('should return the correct path names', () => {
-      assert.strictEqual(daCtx.pathname, '/folder/content');
+      assert.strictEqual(daCtx.sourcePath, '/folder/content.html');
       assert.strictEqual(daCtx.aemPathname, '/folder/content');
     });
 
@@ -83,7 +83,7 @@ describe('DA context', () => {
     });
 
     it('should return the correct path names', () => {
-      assert.strictEqual(daCtx.pathname, '/index');
+      assert.strictEqual(daCtx.sourcePath, '/index.html');
       assert.strictEqual(daCtx.aemPathname, '/');
     });
   });
@@ -94,7 +94,7 @@ describe('DA context', () => {
     });
 
     it('should return the correct path names', () => {
-      assert.strictEqual(daCtx.pathname, '/index');
+      assert.strictEqual(daCtx.sourcePath, '/index.html');
       assert.strictEqual(daCtx.aemPathname, '/');
     });
   });
@@ -105,7 +105,7 @@ describe('DA context', () => {
     });
 
     it('should return the correct path names', () => {
-      assert.strictEqual(daCtx.pathname, '/sub-folder/index');
+      assert.strictEqual(daCtx.sourcePath, '/sub-folder/index.html');
       assert.strictEqual(daCtx.aemPathname, '/sub-folder/');
     });
   });
@@ -115,11 +115,10 @@ describe('DA context', () => {
       daCtx = getDaCtx(reqs.nonHtmlFile);
     });
 
-    it('should return the correct pathname with extension', () => {
-      assert.strictEqual(daCtx.pathname, '/folder/content.json');
+    it('should return the correct path names with extension', () => {
+      assert.strictEqual(daCtx.sourcePath, '/folder/content.json');
       assert.strictEqual(daCtx.aemPathname, '/folder/content.json');
       assert.strictEqual(daCtx.ext, 'json');
-      assert.strictEqual(daCtx.name, 'content');
     });
   });
 
@@ -128,11 +127,10 @@ describe('DA context', () => {
       daCtx = getDaCtx(reqs.plainFile);
     });
 
-    it('should return the correct pathname with extension', () => {
-      assert.strictEqual(daCtx.pathname, '/folder/content.plain.html');
+    it('should return the correct path names with extension', () => {
+      assert.strictEqual(daCtx.sourcePath, '/folder/content.plain.html');
       assert.strictEqual(daCtx.aemPathname, '/folder/content.plain.html');
       assert.strictEqual(daCtx.ext, 'html');
-      assert.strictEqual(daCtx.name, 'content.plain');
     });
   });
 

--- a/test/utils/daCtx.test.js
+++ b/test/utils/daCtx.test.js
@@ -136,6 +136,108 @@ describe('DA context', () => {
     });
   });
 
+  describe('sourcePath', () => {
+    const ctxFor = (pathname) => getDaCtx(
+      new Request(`https://main--site--org.ue.da.live${pathname}`),
+    );
+
+    it('maps / to /index.html', () => {
+      const ctx = ctxFor('/');
+      assert.strictEqual(ctx.sourcePath, '/index.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /index to /index.html', () => {
+      const ctx = ctxFor('/index');
+      assert.strictEqual(ctx.sourcePath, '/index.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /folder/ to /folder/index.html', () => {
+      const ctx = ctxFor('/folder/');
+      assert.strictEqual(ctx.sourcePath, '/folder/index.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /folder to /folder.html', () => {
+      const ctx = ctxFor('/folder');
+      assert.strictEqual(ctx.sourcePath, '/folder.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /page to /page.html', () => {
+      const ctx = ctxFor('/page');
+      assert.strictEqual(ctx.sourcePath, '/page.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /page.html to /page.html', () => {
+      const ctx = ctxFor('/page.html');
+      assert.strictEqual(ctx.sourcePath, '/page.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /Page.HTML to /page.html', () => {
+      const ctx = ctxFor('/Page.HTML');
+      assert.strictEqual(ctx.sourcePath, '/page.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /x.html.html to /x.html.html', () => {
+      const ctx = ctxFor('/x.html.html');
+      assert.strictEqual(ctx.sourcePath, '/x.html.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /Media/Logo.PNG to /media/logo.png', () => {
+      const ctx = ctxFor('/Media/Logo.PNG');
+      assert.strictEqual(ctx.sourcePath, '/media/logo.png');
+      assert.strictEqual(ctx.ext, 'png');
+    });
+
+    it('maps /sheet.json to /sheet.json', () => {
+      const ctx = ctxFor('/sheet.json');
+      assert.strictEqual(ctx.sourcePath, '/sheet.json');
+      assert.strictEqual(ctx.ext, 'json');
+    });
+
+    it('maps /a/b.plain.html to /a/b.plain.html', () => {
+      const ctx = ctxFor('/a/b.plain.html');
+      assert.strictEqual(ctx.sourcePath, '/a/b.plain.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /a//b to /a/b.html', () => {
+      const ctx = ctxFor('/a//b');
+      assert.strictEqual(ctx.sourcePath, '/a/b.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /.hidden to /.hidden', () => {
+      const ctx = ctxFor('/.hidden');
+      assert.strictEqual(ctx.sourcePath, '/.hidden');
+      assert.strictEqual(ctx.ext, 'hidden');
+    });
+
+    it('maps /page. to /page.', () => {
+      const ctx = ctxFor('/page.');
+      assert.strictEqual(ctx.sourcePath, '/page.');
+      assert.strictEqual(ctx.ext, '');
+    });
+
+    it('maps /explaining to /explaining.html', () => {
+      const ctx = ctxFor('/explaining');
+      assert.strictEqual(ctx.sourcePath, '/explaining.html');
+      assert.strictEqual(ctx.ext, 'html');
+    });
+
+    it('maps /v1.2 to /v1.2', () => {
+      const ctx = ctxFor('/v1.2');
+      assert.strictEqual(ctx.sourcePath, '/v1.2');
+      assert.strictEqual(ctx.ext, '2');
+    });
+  });
+
   describe('Invalid URL context', async () => {
     beforeEach(async () => {
       daCtx = getDaCtx(reqs.invalid);


### PR DESCRIPTION
## Description

### before

4 places rebuilt the store path from `path` and `ext`. `ext` is `html`
- when the request has `.html` or 
- when the request has no extension

so 
- `/` became `/.html` and
- `/page.html` became `/page.html.html`. 

and 
- `GET` fell through to the empty template at HTTP 200
- `POST` returned 201 and wrote to the key (which da-admin doesn't list)

### now

`daCtx.sourcePath` derives it from the filename. 

`ext` is unchanged. 
six unused fields removed

`daSourcePost` refuses with 415 unless
- the target is an html document, and
- the part is `text/html` or untyped
(GET proxies non-html untouched, POST would mangle it)

## Related Issue

Fixes #256.

## How Has This Been Tested

Against real `admin.da.live`. 
- `GET /` and `GET /index.html` served the empty template, now serve the page
- `POST /` wrote `/.html`, which da-admin does not list, now writes `/index.html`.
- a seeded PNG was overwritten by HTML, now survives.

UE save verified against a replayed UES request: 
multipart, part `data`, blob typed `text/html` (that's what `universal-editor-service.cjs` sends)
POST `/` writes `index.html` and reads back at `/`, `/index` and `/index.html`.

## Known limitation

pages already saved at a root or `.html` URL sit at `/{org}/{site}/.html` or `/{org}/{site}/x.html.html`.
this change stops reading them and does not migrate them.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
