### PR TITLE
fix: report why a read failed, and stop head.html deciding whether a document exists

### DIFF
--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -37,6 +37,10 @@ export default async function getHandler({ req, env, daCtx }) {
 
     const storeRes = daSourceGetRes.status === 'fulfilled' ? daSourceGetRes.value : undefined;
     const aemRes = aemProxyRes.status === 'fulfilled' ? aemProxyRes.value : undefined;
+    // the loser is dropped when the other answers 200, so it is logged here
+    [daSourceGetRes, aemProxyRes].forEach(({ status, reason }) => {
+      if (status === 'rejected') console.warn(`${daCtx.path}: ${reason?.error ?? reason}`);
+    });
 
     let response;
     if (storeRes?.status === 200) {

--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -50,10 +50,8 @@ export default async function getHandler({ req, env, daCtx }) {
       response = storeRes;
     } else if (aemProxyRes.status === 'rejected') {
       throw aemProxyRes.reason;
-    } else if (aemRes) {
-      response = aemRes;
     } else {
-      return get404();
+      response = aemRes;
     }
 
     if (/\.svg$/i.test(path)) {

--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -43,7 +43,10 @@ export default async function getHandler({ req, env, daCtx }) {
       response = storeRes;
     } else if (aemRes?.status === 200) {
       response = aemRes;
-    } else if (storeRes && storeRes.status >= 500) {
+    } else if (daSourceGetRes.status === 'rejected') {
+      // the store not answering is the answer; aem.page's 404 would say the image is not there
+      throw daSourceGetRes.reason;
+    } else if (storeRes.status >= 500) {
       response = storeRes;
     } else if (aemRes) {
       response = aemRes;

--- a/src/handlers/get.js
+++ b/src/handlers/get.js
@@ -48,6 +48,8 @@ export default async function getHandler({ req, env, daCtx }) {
       throw daSourceGetRes.reason;
     } else if (storeRes.status >= 500) {
       response = storeRes;
+    } else if (aemProxyRes.status === 'rejected') {
+      throw aemProxyRes.reason;
     } else if (aemRes) {
       response = aemRes;
     } else {

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -51,7 +51,10 @@ export default async function headHandler({ req, env, daCtx }) {
       return aemResponse;
     }
     // the store could not answer, so neither can we; the proxy's 404 would claim it does not exist
-    if (storeRes && storeRes.status >= 500) {
+    if (daSourceHeadRes.status === 'rejected') {
+      throw daSourceHeadRes.reason;
+    }
+    if (storeRes.status >= 500) {
       return storeRes;
     }
     if (aemResponse && aemResponse.status < 500) {

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -43,6 +43,10 @@ export default async function headHandler({ req, env, daCtx }) {
 
     const storeRes = daSourceHeadRes.status === 'fulfilled' ? daSourceHeadRes.value : undefined;
     const aemResponse = aemHeadRes.status === 'fulfilled' ? aemHeadRes.value : null;
+    // the loser is dropped when the other answers 200, so it is logged here
+    [daSourceHeadRes, aemHeadRes].forEach(({ status, reason }) => {
+      if (status === 'rejected') console.warn(`${daCtx.path}: ${reason?.error ?? reason}`);
+    });
 
     if (storeRes?.status === 200) {
       return storeRes;

--- a/src/handlers/head.js
+++ b/src/handlers/head.js
@@ -57,6 +57,9 @@ export default async function headHandler({ req, env, daCtx }) {
     if (storeRes.status >= 500) {
       return storeRes;
     }
+    if (aemHeadRes.status === 'rejected') {
+      throw aemHeadRes.reason;
+    }
     if (aemResponse && aemResponse.status < 500) {
       return aemResponse;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ import { getDaCtx } from './utils/daCtx.js';
 import { isTrustedOrigin } from './utils/constants.js';
 
 import getHandler from './handlers/get.js';
-import { get404, getRobots } from './responses/index.js';
+import { get404, getRobots, upstreamFailure } from './responses/index.js';
+import { UpstreamError } from './utils/upstream.js';
 import headHandler from './handlers/head.js';
 import postHandlers from './handlers/post.js';
 import unknownHandler from './handlers/unknown.js';
@@ -67,8 +68,15 @@ export default {
           resp = unknownHandler();
       }
     } catch (e) {
-      console.error(`500 ${req.method} ${url.pathname}: ${e.name}: ${e.message}`, e);
-      resp = new Response(null, { status: 500 });
+      // an upstream that did not answer is the one failure a route reports rather than throws
+      // over; anything else reaching here is a bug
+      if (e instanceof UpstreamError) {
+        console.warn(`503 ${req.method} ${url.pathname}: ${e.error}`);
+        resp = upstreamFailure(e, req.method);
+      } else {
+        console.error(`500 ${req.method} ${url.pathname}: ${e.name}: ${e.message}`, e);
+        resp = new Response(null, { status: 500 });
+      }
     }
     return withCorsHeaders(resp, req);
   },

--- a/src/index.js
+++ b/src/index.js
@@ -68,8 +68,6 @@ export default {
           resp = unknownHandler();
       }
     } catch (e) {
-      // an upstream that did not answer is the one failure a route reports rather than throws
-      // over; anything else reaching here is a bug
       if (e instanceof UpstreamError) {
         console.warn(`503 ${req.method} ${url.pathname}: ${e.error}`);
         resp = upstreamFailure(e, req.method);

--- a/src/render/metadata.js
+++ b/src/render/metadata.js
@@ -156,8 +156,6 @@ export class Modifiers {
   }
 }
 
-// the sheet only adds metadata to a page that composes without it, so an origin that cannot be
-// reached degrades the same way a 404 does instead of taking the read down
 export async function fetchBulkMetadata(aemCtx) {
   const url = new URL('/metadata.json', aemCtx.previewUrl);
   try {
@@ -178,6 +176,9 @@ export async function fetchBulkMetadata(aemCtx) {
       return Modifiers.fromModifierSheet(metadata.data);
     }
   } catch (e) {
+    // the page renders without the sheet, so an unreachable origin degrades like a 404.
+    // swallowed on purpose rather than thrown to the boundary: a 503 here would fail a read
+    // that already has the document and the head
     console.warn(`${url} could not be read: ${causeOf(e)}`);
   }
   return Modifiers.EMPTY;

--- a/src/render/metadata.js
+++ b/src/render/metadata.js
@@ -13,6 +13,7 @@
 import { select } from 'hast-util-select';
 import { readBlockConfig } from '../utils/hast.js';
 import { withAemAuth } from '../utils/aemCtx.js';
+import { causeOf } from '../utils/upstream.js';
 
 export function extractLocalMetadata(bodyTree) {
   const metaBlock = select('div.metadata', bodyTree);
@@ -155,23 +156,29 @@ export class Modifiers {
   }
 }
 
+// the sheet only adds metadata to a page that composes without it, so an origin that cannot be
+// reached degrades the same way a 404 does instead of taking the read down
 export async function fetchBulkMetadata(aemCtx) {
   const url = new URL('/metadata.json', aemCtx.previewUrl);
-  const response = await fetch(url, withAemAuth(aemCtx));
+  try {
+    const response = await fetch(url, withAemAuth(aemCtx));
 
-  if (response.ok) {
-    const json = await response.json();
-    const metadata = json.default ?? json;
-    if (!metadata) {
-      console.log('Metadata sheet is not valid');
-      return Modifiers.EMPTY;
-    }
+    if (response.ok) {
+      const json = await response.json();
+      const metadata = json?.default ?? json;
+      if (!metadata) {
+        console.log('Metadata sheet is not valid');
+        return Modifiers.EMPTY;
+      }
 
-    if (!Array.isArray(metadata.data)) {
-      console.log('Metadata sheet is not valid');
-      return Modifiers.EMPTY;
+      if (!Array.isArray(metadata.data)) {
+        console.log('Metadata sheet is not valid');
+        return Modifiers.EMPTY;
+      }
+      return Modifiers.fromModifierSheet(metadata.data);
     }
-    return Modifiers.fromModifierSheet(metadata.data);
+  } catch (e) {
+    console.warn(`${url} could not be read: ${causeOf(e)}`);
   }
   return Modifiers.EMPTY;
 }

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -20,8 +20,7 @@ import { CONTENT_STORE, PING } from '../utils/upstream.js';
 
 const RETRY_AFTER_SECONDS = '5';
 
-// a 503 says the store did not answer and the body says it again. Only `x-error` says which of a
-// rate limit, a timeout or a dropped connection it was, without reading the worker log.
+// a 503 says an upstream did not answer. only `x-error` says which one, and how.
 function retryHeaders(error) {
   const headers = [['Retry-After', RETRY_AFTER_SECONDS]];
   if (error) headers.push(['x-error', error]);
@@ -64,7 +63,7 @@ export function get415(message = '') {
   return daResp({ body: message, status: 415, contentType: 'text/html' });
 }
 
-export function get503(message = '', error = '') {
+function get503(message = '', error = '') {
   return daResp({
     body: message,
     status: 503,
@@ -75,7 +74,7 @@ export function get503(message = '', error = '') {
 
 // a refused write is never rendered. The Universal Editor Service embeds the body verbatim in
 // its problem+json error string, so plain text is what an author is shown.
-export function post503(message = '', error = '') {
+function post503(message = '', error = '') {
   return daResp({
     body: message,
     status: 503,
@@ -98,7 +97,7 @@ export function head401() {
   return new Response(null, { status: 401 });
 }
 
-export function head503(error = '') {
+function head503(error = '') {
   return new Response(null, { status: 503, headers: retryHeaders(error) });
 }
 

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -9,7 +9,14 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { DEFAULT_UNAUTHORIZED_HTML_MESSAGE } from '../utils/constants.js';
+import {
+  AEM_UNREACHABLE_HTML_MESSAGE,
+  DEFAULT_UNAUTHORIZED_HTML_MESSAGE,
+  SOURCE_UNDETERMINED_MESSAGE,
+  SOURCE_UNREACHABLE_HTML_MESSAGE,
+  SOURCE_UNREACHABLE_MESSAGE,
+} from '../utils/constants.js';
+import { CONTENT_STORE, PING } from '../utils/upstream.js';
 
 const RETRY_AFTER_SECONDS = '5';
 
@@ -104,4 +111,28 @@ export function getRobots() {
 Disallow: /`;
 
   return daResp({ body, status: 200 });
+}
+
+/**
+ * Renders an UpstreamError as the response for the method that asked. This is the only place a
+ * 503 is built, so a route reports which upstream did not answer and nothing else.
+ *
+ * @param {import('../utils/upstream.js').UpstreamError} failure
+ * @param {string} method
+ */
+export function upstreamFailure({ upstream, error }, method) {
+  if (method === 'HEAD') return head503(error);
+  if (method === 'POST') {
+    return post503(
+      upstream === PING ? SOURCE_UNDETERMINED_MESSAGE : SOURCE_UNREACHABLE_MESSAGE,
+      error,
+    );
+  }
+  // the body is what an author reads in the editor, so it names the system that failed
+  return get503(
+    upstream === PING || upstream === CONTENT_STORE
+      ? SOURCE_UNREACHABLE_HTML_MESSAGE
+      : AEM_UNREACHABLE_HTML_MESSAGE,
+    error,
+  );
 }

--- a/src/responses/index.js
+++ b/src/responses/index.js
@@ -113,13 +113,6 @@ Disallow: /`;
   return daResp({ body, status: 200 });
 }
 
-/**
- * Renders an UpstreamError as the response for the method that asked. This is the only place a
- * 503 is built, so a route reports which upstream did not answer and nothing else.
- *
- * @param {import('../utils/upstream.js').UpstreamError} failure
- * @param {string} method
- */
 export function upstreamFailure({ upstream, error }, method) {
   if (method === 'HEAD') return head503(error);
   if (method === 'POST') {
@@ -128,7 +121,6 @@ export function upstreamFailure({ upstream, error }, method) {
       error,
     );
   }
-  // the body is what an author reads in the editor, so it names the system that failed
   return get503(
     upstream === PING || upstream === CONTENT_STORE
       ? SOURCE_UNREACHABLE_HTML_MESSAGE

--- a/src/routes/aem-proxy.js
+++ b/src/routes/aem-proxy.js
@@ -14,6 +14,9 @@ import {
   applyQuickEditToScript,
   getQuickEditCookiePath,
 } from '../utils/quick-edit.js';
+import { AEM_PAGE, UpstreamError, reach } from '../utils/upstream.js';
+import { get503 } from '../responses/index.js';
+import { AEM_UNREACHABLE_HTML_MESSAGE } from '../utils/constants.js';
 
 export async function handleAEMProxyRequest({ req, env, daCtx }) {
   const requestUrl = new URL(req.url);
@@ -47,7 +50,15 @@ export async function handleAEMProxyRequest({ req, env, daCtx }) {
   }
 
   console.log(`-> ${aemUrl.toString()}`);
-  let response = await fetch(req, { cf: { cacheTtl: 0 } });
+  let response;
+  try {
+    response = await reach(AEM_PAGE, () => fetch(req, { cf: { cacheTtl: 0 } }));
+  } catch (e) {
+    // this is the whole answer for a css/js/json request, so a rejection would leave the browser
+    // with the worker's bodyless 500
+    if (!(e instanceof UpstreamError)) throw e;
+    return get503(AEM_UNREACHABLE_HTML_MESSAGE, e.error);
+  }
   console.log(`<- ${aemUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
 
   const contentType = (response.headers.get('Content-Type') || '').toLowerCase();

--- a/src/routes/aem-proxy.js
+++ b/src/routes/aem-proxy.js
@@ -14,9 +14,7 @@ import {
   applyQuickEditToScript,
   getQuickEditCookiePath,
 } from '../utils/quick-edit.js';
-import { AEM_PAGE, UpstreamError, reach } from '../utils/upstream.js';
-import { get503 } from '../responses/index.js';
-import { AEM_UNREACHABLE_HTML_MESSAGE } from '../utils/constants.js';
+import { AEM_PAGE, reach } from '../utils/upstream.js';
 
 export async function handleAEMProxyRequest({ req, env, daCtx }) {
   const requestUrl = new URL(req.url);
@@ -50,15 +48,7 @@ export async function handleAEMProxyRequest({ req, env, daCtx }) {
   }
 
   console.log(`-> ${aemUrl.toString()}`);
-  let response;
-  try {
-    response = await reach(AEM_PAGE, () => fetch(req, { cf: { cacheTtl: 0 } }));
-  } catch (e) {
-    // this is the whole answer for a css/js/json request, so a rejection would leave the browser
-    // with the worker's bodyless 500
-    if (!(e instanceof UpstreamError)) throw e;
-    return get503(AEM_UNREACHABLE_HTML_MESSAGE, e.error);
-  }
+  let response = await reach(AEM_PAGE, () => fetch(req, { cf: { cacheTtl: 0 } }));
   console.log(`<- ${aemUrl.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
 
   const contentType = (response.headers.get('Content-Type') || '').toLowerCase();

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -43,6 +43,13 @@ const HTML_POST_TYPE = 'text/html';
 const HEAD_HTML_PATH = '/head.html';
 const NO_BODY_STATUSES = new Set([204, 205, 304]);
 
+/** Adds a header to an upstream response without reading its body. */
+function withHeader(response, name, value) {
+  const headers = new Headers(response.headers);
+  headers.set(name, value);
+  return new Response(response.body, { status: response.status, headers });
+}
+
 export function isHtmlPostType(type) {
   if (!type) return true;
   return type.split(';')[0].trim().toLowerCase() === HTML_POST_TYPE;
@@ -143,20 +150,31 @@ export async function daSourceGet({ req, env, daCtx }) {
   const sourceResp = sourceResult.value;
   console.log(`<- ${daCtx.sourcePath}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
+  // the store's status is the answer, so a head.html that did not answer is named rather than
+  // thrown. otherwise an aem.page outage hides behind the store's status
+  const headFailure = headResult.status === 'rejected' ? headResult.reason : undefined;
+  if (headFailure) console.warn(`${daCtx.sourcePath}: ${headFailure.error}`);
+  const headErrorHeaders = headFailure ? [['x-error', headFailure.error]] : [];
+
   // the store is the only thing to see the token, and the authorbus extension recovers off the
   // da:401 meta rather than the status, so a refusal from the store gets that shell
   if (sourceResp.status === 401 || sourceResp.status === 403) {
-    return daResp({ body: UNAUTHORIZED_HTML_MESSAGE, status: sourceResp.status, contentType: 'text/html' });
+    return daResp({
+      body: UNAUTHORIZED_HTML_MESSAGE,
+      status: sourceResp.status,
+      contentType: 'text/html',
+      headers: headErrorHeaders,
+    });
   }
 
   // only a 404 means "this document is not here". Composing the starter template over anything
   // else hands the author a blank page to save over a document that exists.
   if (sourceResp.status !== 200 && sourceResp.status !== 404) {
-    return sourceResp;
+    return headFailure ? withHeader(sourceResp, 'x-error', headFailure.error) : sourceResp;
   }
 
-  // the store has answered by now, so a head.html failure is reported here
-  if (headResult.status === 'rejected') throw headResult.reason;
+  // the store answered 200 or 404, so a head.html failure is reported
+  if (headFailure) throw headFailure;
   const head = headResult.value;
 
   // head.html carries the project's scripts and styles, not the answer to whether the document

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -40,7 +40,7 @@ import getStore from '../storage/store.js';
 import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
 const HTML_POST_TYPE = 'text/html';
-const HEAD_PATH = '/head.html';
+const HEAD_HTML_PATH = '/head.html';
 const NO_BODY_STATUSES = new Set([204, 205, 304]);
 
 export function isHtmlPostType(type) {
@@ -81,6 +81,8 @@ async function getPageTemplate(env, daCtx, aemCtx) {
     return DEFAULT_HTML_TEMPLATE;
   }
 
+  // a 404 means no template. a host that did not answer might have one, and the author would
+  // save the default over it
   const templatePath = matchingTemplates[0].template;
   const { html } = await getAEMHtml(aemCtx, templatePath);
   if (html) {
@@ -134,12 +136,10 @@ export async function daSourceGet({ req, env, daCtx }) {
   // the store lookup costs a round trip, so it runs alongside head.html rather than after it
   const aemCtx = getAemCtx(env, daCtx);
   const [headResult, sourceResult] = await Promise.allSettled([
-    getAEMHtml(aemCtx, HEAD_PATH),
+    getAEMHtml(aemCtx, HEAD_HTML_PATH),
     readSource(env, daCtx, { method: 'GET', headers }),
   ]);
   if (sourceResult.status === 'rejected') throw sourceResult.reason;
-  if (headResult.status === 'rejected') throw headResult.reason;
-  const head = headResult.value;
   const sourceResp = sourceResult.value;
   console.log(`<- ${daCtx.sourcePath}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
@@ -155,6 +155,10 @@ export async function daSourceGet({ req, env, daCtx }) {
     return sourceResp;
   }
 
+  // the store has answered by now, so a head.html failure is reported here
+  if (headResult.status === 'rejected') throw headResult.reason;
+  const head = headResult.value;
+
   // head.html carries the project's scripts and styles, not the answer to whether the document
   // is there, so only a 404 is read as "this branch has no head". Anything else is passed on.
   if (head.status === 401 || head.status === 403) {
@@ -167,12 +171,11 @@ export async function daSourceGet({ req, env, daCtx }) {
       body: bodied ? BRANCH_UNAVAILABLE_HTML_MESSAGE : null,
       status: head.status,
       contentType: bodied ? 'text/html' : undefined,
-      headers: [['x-error', `${HEAD_PATH} answered ${head.status}`]],
+      headers: [['x-error', `${HEAD_HTML_PATH} answered ${head.status}`]],
     });
   }
 
-  // with no head.html, head.html is the only thing on this path that knows the site is there at
-  // all, so a store with nothing either is the branch being absent rather than a new document
+  // only head.html knows the site exists, so 404 from both is a missing branch, not a new document
   if (sourceResp.status === 404 && head.status === 404) {
     // quick-edit still needs a working shell (with the import map) so the editor
     // can load into this page, even when the AEM branch doesn't exist yet.

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -131,15 +131,12 @@ export async function daSourceGet({ req, env, daCtx }) {
     return response;
   }
 
-  // the store lookup costs a round trip, so it runs alongside head.html rather than after it.
-  // allSettled rather than all, so which of the two is reported does not depend on which
-  // rejected first
+  // the store lookup costs a round trip, so it runs alongside head.html rather than after it
   const aemCtx = getAemCtx(env, daCtx);
   const [headResult, sourceResult] = await Promise.allSettled([
     getAEMHtml(aemCtx, HEAD_PATH),
     readSource(env, daCtx, { method: 'GET', headers }),
   ]);
-  // the store holds the document, so a store that did not answer is the thing to report
   if (sourceResult.status === 'rejected') throw sourceResult.reason;
   if (headResult.status === 'rejected') throw headResult.reason;
   const head = headResult.value;

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -43,10 +43,10 @@ const HTML_POST_TYPE = 'text/html';
 const HEAD_HTML_PATH = '/head.html';
 const NO_BODY_STATUSES = new Set([204, 205, 304]);
 
-/** Names what stopped head.html being a head fragment, or undefined if nothing did. */
+/** Names what went wrong with head.html, or undefined if nothing did. A 404 is an answer. */
 function headUnusable(failure, head) {
-  if (failure) return failure.error;
-  if (head.status === 200) return undefined;
+  if (failure) return failure.error ?? causeOf(failure);
+  if (head.status === 200 || head.status === 404) return undefined;
   return `${HEAD_HTML_PATH} answered ${head.status}`;
 }
 
@@ -54,7 +54,11 @@ function headUnusable(failure, head) {
 function withHeader(response, name, value) {
   const headers = new Headers(response.headers);
   headers.set(name, value);
-  return new Response(response.body, { status: response.status, headers });
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 export function isHtmlPostType(type) {
@@ -184,7 +188,12 @@ export async function daSourceGet({ req, env, daCtx }) {
   // a 401 or 403 is answered rather than composed head-less, because the authorbus extension
   // refreshes the token off the da:401 shell
   if (head?.status === 401 || head?.status === 403) {
-    return daResp({ body: UNAUTHORIZED_HTML_MESSAGE, status: head.status, contentType: 'text/html' });
+    return daResp({
+      body: UNAUTHORIZED_HTML_MESSAGE,
+      status: head.status,
+      contentType: 'text/html',
+      headers: headHeaders,
+    });
   }
 
   // with nothing in the store, head.html is the only thing that knows the site exists
@@ -216,7 +225,8 @@ export async function daSourceGet({ req, env, daCtx }) {
     : await getPageTemplate(env, daCtx, aemCtx);
 
   // compose the page the same way for every request type
-  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, head?.html);
+  const headHtml = head?.status === 200 ? head.html : undefined;
+  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, headHtml);
 
   // layer the request-specific instrumentation on top of the composed page
   const extraHeaders = [...headHeaders];

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -22,21 +22,17 @@ import {
   applyQuickEditToDocument, buildQuickEditCookie, buildQuickEditNotFoundResponse,
 } from '../utils/quick-edit.js';
 import {
-  daResp, get401, get404, get415, get503, head401, head503, post405, post503,
+  daResp, get401, get404, get415, head401, post405,
 } from '../responses/index.js';
 import {
-  AEM_UNREACHABLE_HTML_MESSAGE,
   BRANCH_NOT_FOUND_HTML_MESSAGE,
   BRANCH_UNAVAILABLE_HTML_MESSAGE,
   DEFAULT_HTML_TEMPLATE,
   SOURCE_BUS_READ_ONLY_MESSAGE,
-  SOURCE_UNDETERMINED_MESSAGE,
-  SOURCE_UNREACHABLE_HTML_MESSAGE,
-  SOURCE_UNREACHABLE_MESSAGE,
   UNAUTHORIZED_HTML_MESSAGE,
 } from '../utils/constants.js';
 import {
-  CONTENT_STORE, PING, UpstreamError, causeOf, reach,
+  CONTENT_STORE, PING, causeOf, reach,
 } from '../utils/upstream.js';
 import { getSiteConfig } from '../storage/config.js';
 import isSourceBus from '../storage/source-bus.js';
@@ -46,7 +42,6 @@ import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 const HTML_POST_TYPE = 'text/html';
 const HEAD_PATH = '/head.html';
 const NO_BODY_STATUSES = new Set([204, 205, 304]);
-const STORE_UPSTREAMS = new Set([PING, CONTENT_STORE]);
 
 export function isHtmlPostType(type) {
   if (!type) return true;
@@ -109,7 +104,7 @@ async function readSource(env, daCtx, init) {
   return reach(CONTENT_STORE, () => store.fetch(store.url, init));
 }
 
-async function readAndCompose({ req, env, daCtx }) {
+export async function daSourceGet({ req, env, daCtx }) {
   const { ext, authToken } = daCtx;
 
   // check if Authorization header is present
@@ -222,29 +217,7 @@ async function readAndCompose({ req, env, daCtx }) {
   });
 }
 
-/**
- * An upstream that did not answer is a 503 naming the cause, and anything else is a bug.
- */
-function unreachable(e, respond) {
-  if (!(e instanceof UpstreamError)) throw e;
-  return respond(e);
-}
-
-export async function daSourceGet({ req, env, daCtx }) {
-  try {
-    return await readAndCompose({ req, env, daCtx });
-  } catch (e) {
-    // the body is what an author reads in the editor, so it names the system that failed
-    return unreachable(e, ({ upstream, error }) => get503(
-      STORE_UPSTREAMS.has(upstream)
-        ? SOURCE_UNREACHABLE_HTML_MESSAGE
-        : AEM_UNREACHABLE_HTML_MESSAGE,
-      error,
-    ));
-  }
-}
-
-async function readHead({ env, daCtx }) {
+export async function daSourceHead({ env, daCtx }) {
   const { authToken } = daCtx;
 
   if (!authToken) {
@@ -259,15 +232,7 @@ async function readHead({ env, daCtx }) {
   return new Response(null, { status: response.status, headers: response.headers });
 }
 
-export async function daSourceHead({ env, daCtx }) {
-  try {
-    return await readHead({ env, daCtx });
-  } catch (e) {
-    return unreachable(e, ({ error }) => head503(error));
-  }
-}
-
-async function writeSource({ req, env, daCtx }) {
+export async function daSourcePost({ req, env, daCtx }) {
   const { sourcePath, ext, authToken } = daCtx;
 
   // the body is rewritten as HTML below, so anything but an HTML document would be
@@ -324,16 +289,4 @@ async function writeSource({ req, env, daCtx }) {
   }
 
   return get415();
-}
-
-export async function daSourcePost({ req, env, daCtx }) {
-  try {
-    return await writeSource({ req, env, daCtx });
-  } catch (e) {
-    // nothing was written either way, and which of the two failed decides what an author is told
-    return unreachable(e, ({ upstream, error }) => post503(
-      upstream === PING ? SOURCE_UNDETERMINED_MESSAGE : SOURCE_UNREACHABLE_MESSAGE,
-      error,
-    ));
-  }
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -26,6 +26,7 @@ import {
 } from '../responses/index.js';
 import {
   BRANCH_NOT_FOUND_HTML_MESSAGE,
+  BRANCH_UNAVAILABLE_HTML_MESSAGE,
   DEFAULT_HTML_TEMPLATE,
   SOURCE_BUS_READ_ONLY_MESSAGE,
   SOURCE_UNDETERMINED_MESSAGE,
@@ -33,29 +34,16 @@ import {
   SOURCE_UNREACHABLE_MESSAGE,
   UNAUTHORIZED_HTML_MESSAGE,
 } from '../utils/constants.js';
+import {
+  CONTENT_STORE, PING, UpstreamError, causeOf, reach,
+} from '../utils/upstream.js';
 import { getSiteConfig } from '../storage/config.js';
 import isSourceBus from '../storage/source-bus.js';
 import getStore from '../storage/store.js';
 import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
 const HTML_POST_TYPE = 'text/html';
-
-/**
- * Renders a failure for the `x-error` header.
- */
-function causeOf(e) {
-  return `${e?.name ?? 'Error'}: ${e?.message ?? e}`
-    .replace(/[^\x20-\x7e]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, 1024);
-}
-
-function probeFailed(e, method, sourcePath) {
-  const cause = `/ping failed: ${causeOf(e)}`;
-  console.warn(`503 ${method} ${sourcePath}, ${cause}`);
-  return cause;
-}
+const HEAD_PATH = '/head.html';
 
 export function isHtmlPostType(type) {
   if (!type) return true;
@@ -77,6 +65,7 @@ async function getPageTemplate(env, daCtx, aemCtx) {
   try {
     config = await getSiteConfig(env, daCtx);
   } catch (e) {
+    console.warn(`no site config for ${daCtx.org}/${daCtx.site}: ${causeOf(e)}`);
     return DEFAULT_HTML_TEMPLATE;
   }
 
@@ -95,48 +84,29 @@ async function getPageTemplate(env, daCtx, aemCtx) {
   }
 
   const templatePath = matchingTemplates[0].template;
-  const templateHtml = await getAEMHtml(aemCtx, templatePath);
-  if (templateHtml) {
-    return templateHtml;
+  const { html } = await getAEMHtml(aemCtx, templatePath);
+  if (html) {
+    return html;
   }
 
   return DEFAULT_HTML_TEMPLATE;
 }
 
 /**
- * Sends a request to a store and reports why it could not be reached at all.
+ * Reads from the store that holds the site. Throws an UpstreamError when either the probe that
+ * picks the store or the store itself did not answer.
  *
- * @returns {Promise<{response?: Response, error?: string}>}
- */
-async function reachStore(store, send) {
-  try {
-    return { response: await send() };
-  } catch (e) {
-    const error = causeOf(e);
-    console.warn(`503 ${store.url}, the store could not be reached: ${error}`);
-    return { error };
-  }
-}
-
-/**
- * Reads from the store that holds the site.
- *
- * @returns {Promise<{response?: Response, error?: string}>} `error` says why there is no response
+ * @returns {Promise<Response>}
  */
 async function readSource(env, daCtx, init) {
-  let onSourceBus;
-  try {
-    onSourceBus = await isSourceBus(env, daCtx);
-  } catch (e) {
-    return { error: probeFailed(e, init.method, daCtx.sourcePath) };
-  }
+  const onSourceBus = await reach(PING, () => isSourceBus(env, daCtx));
 
   const store = getStore(env, daCtx, onSourceBus);
   console.log(`-> ${init.method} ${store.url.toString()}`);
-  return reachStore(store, () => store.fetch(store.url, init));
+  return reach(CONTENT_STORE, () => store.fetch(store.url, init));
 }
 
-export async function daSourceGet({ req, env, daCtx }) {
+async function readAndCompose({ req, env, daCtx }) {
   const { ext, authToken } = daCtx;
 
   // check if Authorization header is present
@@ -158,27 +128,24 @@ export async function daSourceGet({ req, env, daCtx }) {
   if (ext !== 'html') {
     // for non-HTML files, simply proxy the request without processing. A refusal is passed on as
     // itself: nothing renders an image, so the da:401 shell would only corrupt it.
-    const { response, error } = await readSource(env, daCtx, { method: 'GET', headers });
-    if (!response) return get503(SOURCE_UNREACHABLE_HTML_MESSAGE, error);
+    const response = await readSource(env, daCtx, { method: 'GET', headers });
     console.log(`<- ${daCtx.sourcePath}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
     return response;
   }
 
-  // the store lookup costs a round trip, so it runs alongside head.html rather than after it
+  // the store lookup costs a round trip, so it runs alongside head.html rather than after it.
+  // allSettled rather than all, so which of the two is reported does not depend on which
+  // rejected first
   const aemCtx = getAemCtx(env, daCtx);
-  const [headHtml, { response: sourceResp, error: sourceError }] = await Promise.all([
-    getAEMHtml(aemCtx, '/head.html'),
+  const [headResult, sourceResult] = await Promise.allSettled([
+    getAEMHtml(aemCtx, HEAD_PATH),
     readSource(env, daCtx, { method: 'GET', headers }),
   ]);
-  if (!headHtml) {
-    // quick-edit still needs a working shell (with the import map) so the editor
-    // can load into this page, even when the AEM branch doesn't exist yet.
-    if (isQuickEdit) {
-      return buildQuickEditNotFoundResponse();
-    }
-    return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
-  }
-  if (!sourceResp) return get503(SOURCE_UNREACHABLE_HTML_MESSAGE, sourceError);
+  // the store holds the document, so a store that did not answer is the thing to report
+  if (sourceResult.status === 'rejected') throw sourceResult.reason;
+  if (headResult.status === 'rejected') throw headResult.reason;
+  const head = headResult.value;
+  const sourceResp = sourceResult.value;
   console.log(`<- ${daCtx.sourcePath}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
   // the store is the only thing to see the token, and the authorbus extension recovers off the
@@ -193,13 +160,38 @@ export async function daSourceGet({ req, env, daCtx }) {
     return sourceResp;
   }
 
+  // head.html carries the project's scripts and styles, not the answer to whether the document
+  // is there, so only a 404 is read as "this branch has no head". Anything else is passed on.
+  if (head.status === 401 || head.status === 403) {
+    return daResp({ body: UNAUTHORIZED_HTML_MESSAGE, status: head.status, contentType: 'text/html' });
+  }
+  if (head.status !== 200 && head.status !== 404) {
+    return daResp({
+      body: BRANCH_UNAVAILABLE_HTML_MESSAGE,
+      status: head.status,
+      contentType: 'text/html',
+      headers: [['x-error', `${HEAD_PATH} answered ${head.status}`]],
+    });
+  }
+
+  // with no head.html, head.html is the only thing on this path that knows the site is there at
+  // all, so a store with nothing either is the branch being absent rather than a new document
+  if (sourceResp.status === 404 && head.status === 404) {
+    // quick-edit still needs a working shell (with the import map) so the editor
+    // can load into this page, even when the AEM branch doesn't exist yet.
+    if (isQuickEdit) {
+      return buildQuickEditNotFoundResponse();
+    }
+    return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
+  }
+
   // use the stored content when available, otherwise fall back to a template
   const bodyHtml = sourceResp.status === 200
     ? await sourceResp.text()
-    : await getPageTemplate(env, daCtx, aemCtx, headHtml);
+    : await getPageTemplate(env, daCtx, aemCtx);
 
   // compose the page the same way for every request type
-  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, headHtml);
+  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, head.html);
 
   // layer the request-specific instrumentation on top of the composed page
   const extraHeaders = [];
@@ -225,7 +217,23 @@ export async function daSourceGet({ req, env, daCtx }) {
   });
 }
 
-export async function daSourceHead({ env, daCtx }) {
+/**
+ * An upstream that did not answer is a 503 naming the cause, and anything else is a bug.
+ */
+function unreachable(e, respond) {
+  if (!(e instanceof UpstreamError)) throw e;
+  return respond(e);
+}
+
+export async function daSourceGet({ req, env, daCtx }) {
+  try {
+    return await readAndCompose({ req, env, daCtx });
+  } catch (e) {
+    return unreachable(e, ({ error }) => get503(SOURCE_UNREACHABLE_HTML_MESSAGE, error));
+  }
+}
+
+async function readHead({ env, daCtx }) {
   const { authToken } = daCtx;
 
   if (!authToken) {
@@ -235,13 +243,20 @@ export async function daSourceHead({ env, daCtx }) {
   const headers = new Headers();
   headers.set('Authorization', authToken);
 
-  const { response, error } = await readSource(env, daCtx, { method: 'HEAD', headers });
-  if (!response) return head503(error);
+  const response = await readSource(env, daCtx, { method: 'HEAD', headers });
   console.log(`<- HEAD ${daCtx.sourcePath}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
   return new Response(null, { status: response.status, headers: response.headers });
 }
 
-export async function daSourcePost({ req, env, daCtx }) {
+export async function daSourceHead({ env, daCtx }) {
+  try {
+    return await readHead({ env, daCtx });
+  } catch (e) {
+    return unreachable(e, ({ error }) => head503(error));
+  }
+}
+
+async function writeSource({ req, env, daCtx }) {
   const { sourcePath, ext, authToken } = daCtx;
 
   // the body is rewritten as HTML below, so anything but an HTML document would be
@@ -276,13 +291,7 @@ export async function daSourcePost({ req, env, daCtx }) {
     const bodyContent = toHtml(bodyNode);
 
     // the payload is settled, so the only question left is where it goes
-    let onSourceBus;
-    try {
-      onSourceBus = await isSourceBus(env, daCtx);
-    } catch (e) {
-      const cause = probeFailed(e, 'POST', sourcePath);
-      return post503(SOURCE_UNDETERMINED_MESSAGE, cause);
-    }
+    const onSourceBus = await reach(PING, () => isSourceBus(env, daCtx));
 
     if (onSourceBus) {
       console.log(`405 POST ${sourcePath}, writes to the source bus are refused through the preview proxy. write directly to the source bus instead.`);
@@ -294,15 +303,26 @@ export async function daSourcePost({ req, env, daCtx }) {
     const body = new FormData();
     body.set('data', new Blob([bodyContent], { type: 'text/html' }));
     console.log(`-> ${store.url.toString()}`);
-    const { response, error } = await reachStore(store, () => store.fetch(new Request(store.url, {
+    const response = await reach(CONTENT_STORE, () => store.fetch(new Request(store.url, {
       method: 'POST',
       body,
       headers: { Authorization: authToken },
     })));
-    if (!response) return post503(SOURCE_UNREACHABLE_MESSAGE, error);
     console.log(`<- ${store.url.toString()}. ${response.status} ${response.statusText}`, { status: response.status, statusText: response.statusText });
     return response;
   }
 
   return get415();
+}
+
+export async function daSourcePost({ req, env, daCtx }) {
+  try {
+    return await writeSource({ req, env, daCtx });
+  } catch (e) {
+    // nothing was written either way, and which of the two failed decides what an author is told
+    return unreachable(e, ({ upstream, error }) => post503(
+      upstream === PING ? SOURCE_UNDETERMINED_MESSAGE : SOURCE_UNREACHABLE_MESSAGE,
+      error,
+    ));
+  }
 }

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -25,6 +25,7 @@ import {
   daResp, get401, get404, get415, get503, head401, head503, post405, post503,
 } from '../responses/index.js';
 import {
+  AEM_UNREACHABLE_HTML_MESSAGE,
   BRANCH_NOT_FOUND_HTML_MESSAGE,
   BRANCH_UNAVAILABLE_HTML_MESSAGE,
   DEFAULT_HTML_TEMPLATE,
@@ -44,6 +45,8 @@ import { restoreAbsoluteImages } from '../render/rewrite-images.js';
 
 const HTML_POST_TYPE = 'text/html';
 const HEAD_PATH = '/head.html';
+const NO_BODY_STATUSES = new Set([204, 205, 304]);
+const STORE_UPSTREAMS = new Set([PING, CONTENT_STORE]);
 
 export function isHtmlPostType(type) {
   if (!type) return true;
@@ -166,10 +169,12 @@ async function readAndCompose({ req, env, daCtx }) {
     return daResp({ body: UNAUTHORIZED_HTML_MESSAGE, status: head.status, contentType: 'text/html' });
   }
   if (head.status !== 200 && head.status !== 404) {
+    // 204, 205 and 304 forbid a body, and handing one to the Response constructor throws
+    const bodied = !NO_BODY_STATUSES.has(head.status);
     return daResp({
-      body: BRANCH_UNAVAILABLE_HTML_MESSAGE,
+      body: bodied ? BRANCH_UNAVAILABLE_HTML_MESSAGE : null,
       status: head.status,
-      contentType: 'text/html',
+      contentType: bodied ? 'text/html' : undefined,
       headers: [['x-error', `${HEAD_PATH} answered ${head.status}`]],
     });
   }
@@ -229,7 +234,13 @@ export async function daSourceGet({ req, env, daCtx }) {
   try {
     return await readAndCompose({ req, env, daCtx });
   } catch (e) {
-    return unreachable(e, ({ error }) => get503(SOURCE_UNREACHABLE_HTML_MESSAGE, error));
+    // the body is what an author reads in the editor, so it names the system that failed
+    return unreachable(e, ({ upstream, error }) => get503(
+      STORE_UPSTREAMS.has(upstream)
+        ? SOURCE_UNREACHABLE_HTML_MESSAGE
+        : AEM_UNREACHABLE_HTML_MESSAGE,
+      error,
+    ));
   }
 }
 

--- a/src/routes/da-admin.js
+++ b/src/routes/da-admin.js
@@ -43,6 +43,13 @@ const HTML_POST_TYPE = 'text/html';
 const HEAD_HTML_PATH = '/head.html';
 const NO_BODY_STATUSES = new Set([204, 205, 304]);
 
+/** Names what stopped head.html being a head fragment, or undefined if nothing did. */
+function headUnusable(failure, head) {
+  if (failure) return failure.error;
+  if (head.status === 200) return undefined;
+  return `${HEAD_HTML_PATH} answered ${head.status}`;
+}
+
 /** Adds a header to an upstream response without reading its body. */
 function withHeader(response, name, value) {
   const headers = new Headers(response.headers);
@@ -150,11 +157,12 @@ export async function daSourceGet({ req, env, daCtx }) {
   const sourceResp = sourceResult.value;
   console.log(`<- ${daCtx.sourcePath}. ${sourceResp.status} ${sourceResp.statusText}`, { status: sourceResp.status, statusText: sourceResp.statusText });
 
-  // the store's status is the answer, so a head.html that did not answer is named rather than
-  // thrown. otherwise an aem.page outage hides behind the store's status
   const headFailure = headResult.status === 'rejected' ? headResult.reason : undefined;
-  if (headFailure) console.warn(`${daCtx.sourcePath}: ${headFailure.error}`);
-  const headErrorHeaders = headFailure ? [['x-error', headFailure.error]] : [];
+  const head = headFailure ? undefined : headResult.value;
+  // an unusable head.html is named, otherwise an aem.page outage hides behind the store's status
+  const headNote = headUnusable(headFailure, head);
+  if (headNote) console.warn(`${daCtx.sourcePath}: ${headNote}`);
+  const headHeaders = headNote ? [['x-error', headNote]] : [];
 
   // the store is the only thing to see the token, and the authorbus extension recovers off the
   // da:401 meta rather than the status, so a refusal from the store gets that shell
@@ -163,44 +171,43 @@ export async function daSourceGet({ req, env, daCtx }) {
       body: UNAUTHORIZED_HTML_MESSAGE,
       status: sourceResp.status,
       contentType: 'text/html',
-      headers: headErrorHeaders,
+      headers: headHeaders,
     });
   }
 
   // only a 404 means "this document is not here". Composing the starter template over anything
   // else hands the author a blank page to save over a document that exists.
   if (sourceResp.status !== 200 && sourceResp.status !== 404) {
-    return headFailure ? withHeader(sourceResp, 'x-error', headFailure.error) : sourceResp;
+    return headNote ? withHeader(sourceResp, 'x-error', headNote) : sourceResp;
   }
 
-  // the store answered 200 or 404, so a head.html failure is reported
-  if (headFailure) throw headFailure;
-  const head = headResult.value;
-
-  // head.html carries the project's scripts and styles, not the answer to whether the document
-  // is there, so only a 404 is read as "this branch has no head". Anything else is passed on.
-  if (head.status === 401 || head.status === 403) {
+  // a 401 or 403 is answered rather than composed head-less, because the authorbus extension
+  // refreshes the token off the da:401 shell
+  if (head?.status === 401 || head?.status === 403) {
     return daResp({ body: UNAUTHORIZED_HTML_MESSAGE, status: head.status, contentType: 'text/html' });
   }
-  if (head.status !== 200 && head.status !== 404) {
-    // 204, 205 and 304 forbid a body, and handing one to the Response constructor throws
-    const bodied = !NO_BODY_STATUSES.has(head.status);
-    return daResp({
-      body: bodied ? BRANCH_UNAVAILABLE_HTML_MESSAGE : null,
-      status: head.status,
-      contentType: bodied ? 'text/html' : undefined,
-      headers: [['x-error', `${HEAD_HTML_PATH} answered ${head.status}`]],
-    });
-  }
 
-  // only head.html knows the site exists, so 404 from both is a missing branch, not a new document
-  if (sourceResp.status === 404 && head.status === 404) {
-    // quick-edit still needs a working shell (with the import map) so the editor
-    // can load into this page, even when the AEM branch doesn't exist yet.
-    if (isQuickEdit) {
-      return buildQuickEditNotFoundResponse();
+  // with nothing in the store, head.html is the only thing that knows the site exists
+  if (sourceResp.status === 404) {
+    if (headFailure) throw headFailure;
+    if (head.status === 404) {
+      // quick-edit still needs a working shell (with the import map) so the editor
+      // can load into this page, even when the AEM branch doesn't exist yet.
+      if (isQuickEdit) {
+        return buildQuickEditNotFoundResponse();
+      }
+      return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
     }
-    return get404(BRANCH_NOT_FOUND_HTML_MESSAGE);
+    if (head.status !== 200) {
+      // 204, 205 and 304 forbid a body, and handing one to the Response constructor throws
+      const bodied = !NO_BODY_STATUSES.has(head.status);
+      return daResp({
+        body: bodied ? BRANCH_UNAVAILABLE_HTML_MESSAGE : null,
+        status: head.status,
+        contentType: bodied ? 'text/html' : undefined,
+        headers: headHeaders,
+      });
+    }
   }
 
   // use the stored content when available, otherwise fall back to a template
@@ -209,10 +216,10 @@ export async function daSourceGet({ req, env, daCtx }) {
     : await getPageTemplate(env, daCtx, aemCtx);
 
   // compose the page the same way for every request type
-  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, head.html);
+  const documentTree = await composeHtml(daCtx, aemCtx, bodyHtml, head?.html);
 
   // layer the request-specific instrumentation on top of the composed page
-  const extraHeaders = [];
+  const extraHeaders = [...headHeaders];
   if (isQuickEdit) {
     // no upstream AEM CSP to satisfy here, so no nonce is applied
     const entryPath = applyQuickEditToDocument(documentTree, undefined);

--- a/src/utils/aemCtx.js
+++ b/src/utils/aemCtx.js
@@ -12,6 +12,7 @@
 import { fromHtml } from 'hast-util-from-html';
 import { selectAll } from 'hast-util-select';
 import { toHtml } from 'hast-util-to-html';
+import { reach } from './upstream.js';
 
 export function getAemCtx(env, daCtx) {
   const {
@@ -46,12 +47,24 @@ export function withAemAuth(aemCtx, init = {}) {
   return { ...init, headers };
 }
 
+/**
+ * Reads an HTML fragment from the site's preview host.
+ *
+ * A status that is not 200 is reported rather than collapsed, because a 404 means the branch
+ * does not serve this fragment while a 429 or a 5xx says nothing about the branch at all.
+ * A host that does not answer throws an UpstreamError.
+ *
+ * @param {Object} aemCtx The AEM context
+ * @param {string} path
+ * @returns {Promise<{status: number, html?: string}>}
+ */
 export async function getAEMHtml(aemCtx, path) {
   const { previewUrl } = aemCtx;
-  const resp = await fetch(`${previewUrl}${path}`, withAemAuth(aemCtx));
-  if (!resp.ok) return undefined;
-  const headHtml = await resp.text();
-  return headHtml;
+  return reach(path, async () => {
+    const resp = await fetch(`${previewUrl}${path}`, withAemAuth(aemCtx));
+    if (!resp.ok) return { status: resp.status };
+    return { status: resp.status, html: await resp.text() };
+  });
 }
 
 /**

--- a/src/utils/aemCtx.js
+++ b/src/utils/aemCtx.js
@@ -62,7 +62,7 @@ export async function getAEMHtml(aemCtx, path) {
   const { previewUrl } = aemCtx;
   return reach(path, async () => {
     const resp = await fetch(`${previewUrl}${path}`, withAemAuth(aemCtx));
-    if (!resp.ok) return { status: resp.status };
+    if (resp.status !== 200) return { status: resp.status };
     return { status: resp.status, html: await resp.text() };
   });
 }

--- a/src/utils/aemCtx.js
+++ b/src/utils/aemCtx.js
@@ -50,7 +50,7 @@ export function withAemAuth(aemCtx, init = {}) {
 /**
  * Reads an HTML fragment from the site's preview host.
  *
- * A status that is not 200 is reported rather than collapsed, because a 404 means the branch
+ * A status that is not 200 is reported, because a 404 means the branch
  * does not serve this fragment while a 429 or a 5xx says nothing about the branch at all.
  * A host that does not answer throws an UpstreamError.
  *

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -51,7 +51,11 @@ export const DEFAULT_HTML_TEMPLATE = '<body><header></header><main><div></div></
 
 export const BRANCH_NOT_FOUND_HTML_MESSAGE = '<html><body><h1>Not found: Unable to retrieve AEM branch</h1></body></html>';
 
+export const BRANCH_UNAVAILABLE_HTML_MESSAGE = '<html><body><h1>Unable to retrieve AEM branch</h1><p>The preview host refused the request for head.html. The status is its own.</p></body></html>';
+
 export const SOURCE_UNREACHABLE_HTML_MESSAGE = '<html><body><h1>503: Content store unreachable</h1><p>The store that holds this document did not answer. Please retry.</p></body></html>';
+
+export const AEM_UNREACHABLE_HTML_MESSAGE = '<html><body><h1>503: AEM unreachable</h1><p>The site\'s preview host did not answer. Please retry.</p></body></html>';
 
 export const SOURCE_UNREACHABLE_MESSAGE = 'The store that holds this document did not answer, so nothing was written. Please retry.';
 

--- a/src/utils/upstream.js
+++ b/src/utils/upstream.js
@@ -15,11 +15,12 @@ export const CONTENT_STORE = 'content store';
 export const AEM_PAGE = 'aem.page';
 
 /**
- * Renders a failure for the `x-error` header. A header value cannot span lines, so a message
- * carrying a stack would throw where the response is built.
+ * Makes a string safe to append as a header value. A header value cannot span lines, so a
+ * message carrying a stack, or a template path out of the site config sheet, would throw
+ * where the response is built.
  */
-export function causeOf(e) {
-  return `${e?.name ?? 'Error'}: ${e?.message ?? e}`
+function headerSafe(text) {
+  return String(text)
     // eslint-disable-next-line no-control-regex
     .replace(/[^\x20-\x7e]/g, ' ')
     .replace(/\s+/g, ' ')
@@ -28,12 +29,19 @@ export function causeOf(e) {
 }
 
 /**
+ * Renders a failure for the `x-error` header.
+ */
+export function causeOf(e) {
+  return headerSafe(`${e?.name ?? 'Error'}: ${e?.message ?? e}`);
+}
+
+/**
  * An upstream did not answer at all, which is different from answering a status. The route that
  * builds the 503 catches this and puts `error` in the `x-error` header.
  */
 export class UpstreamError extends Error {
   constructor(upstream, cause) {
-    const error = `${upstream} failed: ${causeOf(cause)}`;
+    const error = headerSafe(`${upstream} failed: ${causeOf(cause)}`);
     super(error);
     this.name = 'UpstreamError';
     this.upstream = upstream;
@@ -50,7 +58,8 @@ export async function reach(upstream, send) {
     return await send();
   } catch (e) {
     if (e instanceof UpstreamError) throw e;
-    console.warn(`${upstream} could not be reached: ${causeOf(e)}`);
-    throw new UpstreamError(upstream, e);
+    const failure = new UpstreamError(upstream, e);
+    console.warn(failure.error);
+    throw failure;
   }
 }

--- a/src/utils/upstream.js
+++ b/src/utils/upstream.js
@@ -18,10 +18,12 @@ export const AEM_PAGE = 'aem.page';
  * Makes a string safe to append as a header value. A header value cannot span lines, so a
  * message carrying a stack, or a template path out of the site config sheet, would throw
  * where the response is built.
+ *
+ * @param {*} text
+ * @returns {string}
  */
 function headerSafe(text) {
   return String(text)
-    // eslint-disable-next-line no-control-regex
     .replace(/[^\x20-\x7e]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
@@ -30,14 +32,20 @@ function headerSafe(text) {
 
 /**
  * Renders a failure for the `x-error` header.
+ *
+ * @param {*} e the thrown value, which need not be an Error
+ * @returns {string}
  */
 export function causeOf(e) {
   return headerSafe(`${e?.name ?? 'Error'}: ${e?.message ?? e}`);
 }
 
 /**
- * An upstream did not answer at all, which is different from answering a status. The route that
- * builds the 503 catches this and puts `error` in the `x-error` header.
+ * An upstream did not answer. A status, even a 404, is an answer. The worker boundary puts
+ * `error` in the `x-error` header.
+ *
+ * @param {string} upstream what did not answer
+ * @param {*} cause the thrown value
  */
 export class UpstreamError extends Error {
   constructor(upstream, cause) {
@@ -52,14 +60,16 @@ export class UpstreamError extends Error {
 /**
  * Sends a request to an upstream and reports a failure to reach it as an UpstreamError.
  * An UpstreamError from a nested call is passed on, so the innermost upstream is the one named.
+ *
+ * @param {string} upstream what is being reached
+ * @param {function(): Promise<*>} send
+ * @returns {Promise<*>} whatever `send` resolved to
  */
 export async function reach(upstream, send) {
   try {
     return await send();
   } catch (e) {
     if (e instanceof UpstreamError) throw e;
-    const failure = new UpstreamError(upstream, e);
-    console.warn(failure.error);
-    throw failure;
+    throw new UpstreamError(upstream, e);
   }
 }

--- a/src/utils/upstream.js
+++ b/src/utils/upstream.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export const PING = '/ping';
+export const CONTENT_STORE = 'content store';
+export const AEM_PAGE = 'aem.page';
+
+/**
+ * Renders a failure for the `x-error` header. A header value cannot span lines, so a message
+ * carrying a stack would throw where the response is built.
+ */
+export function causeOf(e) {
+  return `${e?.name ?? 'Error'}: ${e?.message ?? e}`
+    // eslint-disable-next-line no-control-regex
+    .replace(/[^\x20-\x7e]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 1024);
+}
+
+/**
+ * An upstream did not answer at all, which is different from answering a status. The route that
+ * builds the 503 catches this and puts `error` in the `x-error` header.
+ */
+export class UpstreamError extends Error {
+  constructor(upstream, cause) {
+    const error = `${upstream} failed: ${causeOf(cause)}`;
+    super(error);
+    this.name = 'UpstreamError';
+    this.upstream = upstream;
+    this.error = error;
+  }
+}
+
+/**
+ * Sends a request to an upstream and reports a failure to reach it as an UpstreamError.
+ * An UpstreamError from a nested call is passed on, so the innermost upstream is the one named.
+ */
+export async function reach(upstream, send) {
+  try {
+    return await send();
+  } catch (e) {
+    if (e instanceof UpstreamError) throw e;
+    console.warn(`${upstream} could not be reached: ${causeOf(e)}`);
+    throw new UpstreamError(upstream, e);
+  }
+}

--- a/test/handlers/get.test.js
+++ b/test/handlers/get.test.js
@@ -197,14 +197,16 @@ describe('GET handler', () => {
         })).default;
       });
 
-      it('returns 404', async () => {
+      // a rejection here is a bug in the read, not evidence the image is absent
+      it('propagates the failure rather than calling the image absent', async () => {
         const req = new Request('https://main--site--org.ue.da.live/image.png');
         const daCtx = getDaCtx(req);
         const env = {};
 
-        const res = await getHandler({ req, env, daCtx });
-
-        assert.strictEqual(res.status, 404);
+        await assert.rejects(
+          () => getHandler({ req, env, daCtx }),
+          (e) => e.message === 'fail',
+        );
       });
     });
 

--- a/test/handlers/get.test.js
+++ b/test/handlers/get.test.js
@@ -208,6 +208,34 @@ describe('GET handler', () => {
       });
     });
 
+    // the store not holding an image is normal; aem.page not answering is not, and reporting
+    // that pair as 404 told the author the image does not exist
+    describe('when the store has no image and AEM could not be reached', () => {
+      let getHandler;
+
+      beforeEach(async () => {
+        getHandler = (await esmock('../../src/handlers/get.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceGet: async () => new Response('', { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => new Response('', { status: 503, headers: { 'x-error': 'aem.page failed: TypeError: fetch failed' } }),
+          },
+        })).default;
+      });
+
+      it('returns the 503 rather than claiming the image is absent', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png');
+        const daCtx = getDaCtx(req);
+        const env = {};
+
+        const res = await getHandler({ req, env, daCtx });
+
+        assert.strictEqual(res.status, 503);
+        assert.strictEqual(res.headers.get('x-error'), 'aem.page failed: TypeError: fetch failed');
+      });
+    });
+
     describe('when daSourceGet fails and AEM proxy succeeds', () => {
       let getHandler;
 

--- a/test/handlers/get.test.js
+++ b/test/handlers/get.test.js
@@ -14,6 +14,7 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import reqs from '../mocks/req.js';
+import { AEM_PAGE, UpstreamError } from '../../src/utils/upstream.js';
 
 const { getDaCtx } = await import('../../src/utils/daCtx.js');
 
@@ -210,8 +211,8 @@ describe('GET handler', () => {
       });
     });
 
-    // the store not holding an image is normal; aem.page not answering is not, and reporting
-    // that pair as 404 told the author the image does not exist
+    // the store not holding an image is normal; aem.page not answering leaves it unknown, and
+    // 404 would say it is not there
     describe('when the store has no image and AEM could not be reached', () => {
       let getHandler;
 
@@ -221,20 +222,40 @@ describe('GET handler', () => {
             daSourceGet: async () => new Response('', { status: 404 }),
           },
           '../../src/routes/aem-proxy.js': {
-            handleAEMProxyRequest: async () => new Response('', { status: 503, headers: { 'x-error': 'aem.page failed: TypeError: fetch failed' } }),
+            handleAEMProxyRequest: async () => {
+              throw new UpstreamError(AEM_PAGE, new TypeError('fetch failed'));
+            },
           },
         })).default;
       });
 
-      it('returns the 503 rather than claiming the image is absent', async () => {
+      it('propagates rather than claiming the image is absent', async () => {
         const req = new Request('https://main--site--org.ue.da.live/image.png');
         const daCtx = getDaCtx(req);
         const env = {};
 
-        const res = await getHandler({ req, env, daCtx });
+        await assert.rejects(
+          () => getHandler({ req, env, daCtx }),
+          (e) => e instanceof UpstreamError && e.upstream === AEM_PAGE,
+        );
+      });
 
-        assert.strictEqual(res.status, 503);
-        assert.strictEqual(res.headers.get('x-error'), 'aem.page failed: TypeError: fetch failed');
+      it('still prefers the store when it has the image', async () => {
+        getHandler = (await esmock('../../src/handlers/get.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceGet: async () => new Response('bytes', { status: 200 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => {
+              throw new UpstreamError(AEM_PAGE, new TypeError('fetch failed'));
+            },
+          },
+        })).default;
+        const req = new Request('https://main--site--org.ue.da.live/image.png');
+
+        const res = await getHandler({ req, env: {}, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, 200);
       });
     });
 

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -14,6 +14,7 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import reqs from '../mocks/req.js';
+import { AEM_PAGE, UpstreamError } from '../../src/utils/upstream.js';
 
 const { getDaCtx } = await import('../../src/utils/daCtx.js');
 
@@ -265,6 +266,33 @@ describe('HEAD handler', () => {
         const res = await headHandler({ req, env, daCtx });
 
         assert.strictEqual(res.status, 404);
+      });
+    });
+
+    // an aem.page that did not answer leaves the image unknown; 404 would say it is not there
+    describe('when the store has no image and AEM could not be reached', () => {
+      let headHandler;
+
+      beforeEach(async () => {
+        headHandler = (await esmock('../../src/handlers/head.js', {
+          '../../src/routes/da-admin.js': {
+            daSourceHead: async () => new Response(null, { status: 404 }),
+          },
+          '../../src/routes/aem-proxy.js': {
+            handleAEMProxyRequest: async () => {
+              throw new UpstreamError(AEM_PAGE, new TypeError('fetch failed'));
+            },
+          },
+        })).default;
+      });
+
+      it('propagates rather than claiming the image is absent', async () => {
+        const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
+
+        await assert.rejects(
+          () => headHandler({ req, env: {}, daCtx: getDaCtx(req) }),
+          (e) => e instanceof UpstreamError && e.upstream === AEM_PAGE,
+        );
       });
     });
 

--- a/test/handlers/head.test.js
+++ b/test/handlers/head.test.js
@@ -282,14 +282,16 @@ describe('HEAD handler', () => {
         })).default;
       });
 
-      it('returns 404', async () => {
+      // a rejection here is a bug in the read, not evidence the image is absent
+      it('propagates the failure rather than calling the image absent', async () => {
         const req = new Request('https://main--site--org.ue.da.live/image.png', { method: 'HEAD' });
         const daCtx = getDaCtx(req);
         const env = {};
 
-        const res = await headHandler({ req, env, daCtx });
-
-        assert.strictEqual(res.status, 404);
+        await assert.rejects(
+          () => headHandler({ req, env, daCtx }),
+          (e) => e.message === 'fail',
+        );
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -115,6 +115,56 @@ describe('worker fetch handler', () => {
     });
   });
 
+  // the tests above stub a handler. here only the network is stubbed
+  describe('end to end, with nothing answering', () => {
+    afterEach(() => {
+      delete globalThis.fetch;
+    });
+
+    const worker = async () => (await esmock('../src/index.js', {}, {
+      '../src/storage/source-bus.js': {
+        default: async () => {
+          throw new TypeError('Network connection lost');
+        },
+      },
+    })).default;
+
+    const env = {
+      DA_ADMIN: 'https://admin.da.live',
+      AEM_API: 'https://api.aem.live',
+      HLX_ADMIN: 'https://admin.hlx.page',
+      UE_HOST: 'ue.da.live',
+      daadmin: { fetch: async () => new Response('', { status: 200 }) },
+    };
+
+    it('answers a read with a 503 that names the probe', async () => {
+      globalThis.fetch = async () => new Response('<head></head>', { status: 200 });
+      const req = new Request('https://main--site--org.ue.da.live/folder/content', {
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      const res = await (await worker()).fetch(req, env);
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(res.headers.get('x-error'), '/ping failed: TypeError: Network connection lost');
+      assert.match(await res.text(), /Content store unreachable/);
+    });
+
+    it('answers a HEAD the same way, without a body', async () => {
+      globalThis.fetch = async () => new Response('<head></head>', { status: 200 });
+      const req = new Request('https://main--site--org.ue.da.live/folder/content', {
+        method: 'HEAD',
+        headers: { Authorization: 'Bearer t' },
+      });
+
+      const res = await (await worker()).fetch(req, env);
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(await res.text(), '');
+      assert.ok(Number(res.headers.get('Retry-After')) > 0);
+    });
+  });
+
   describe('when a handler throws', () => {
     // a throw used to reject worker.fetch, and the runtime answered a bare 500 with no CORS on it,
     // which the editor cannot read at all

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import esmock from 'esmock';
+import { CONTENT_STORE, PING, UpstreamError } from '../src/utils/upstream.js';
 
 // everything but the POST handler, so a write can be driven through the real route
 const READ_HANDLER_MOCKS = {
@@ -37,6 +38,15 @@ const HANDLER_MOCKS = {
   },
 };
 
+const refusingWorker = async (handler, failure) => (await esmock('../src/index.js', {
+  ...HANDLER_MOCKS,
+  [handler]: {
+    default: async () => {
+      throw failure;
+    },
+  },
+})).default;
+
 const throwingWorker = async (handler) => (await esmock('../src/index.js', {
   ...HANDLER_MOCKS,
   [handler]: {
@@ -47,6 +57,64 @@ const throwingWorker = async (handler) => (await esmock('../src/index.js', {
 })).default;
 
 describe('worker fetch handler', () => {
+  // the routes report which upstream did not answer and throw; this is the only place the 503
+  // is built, so it is the only place that can get it wrong
+  describe('when an upstream did not answer', () => {
+    const storeGone = () => new UpstreamError(CONTENT_STORE, new TypeError('Network connection lost'));
+
+    it('answers 503, not 500', async () => {
+      const worker = await refusingWorker('../src/handlers/get.js', storeGone());
+      const req = new Request('https://main--site--org.ue.da.live/some/path');
+
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.status, 503);
+    });
+
+    it('names the cause in x-error', async () => {
+      const worker = await refusingWorker('../src/handlers/get.js', storeGone());
+      const req = new Request('https://main--site--org.ue.da.live/some/path');
+
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+    });
+
+    it('keeps the CORS headers on it', async () => {
+      const worker = await refusingWorker('../src/handlers/get.js', storeGone());
+      const req = new Request('https://main--site--org.ue.da.live/some/path', {
+        headers: { Origin: 'https://da.live' },
+      });
+
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'https://da.live');
+    });
+
+    it('has no body on a HEAD', async () => {
+      const worker = await refusingWorker('../src/handlers/head.js', storeGone());
+      const req = new Request('https://main--site--org.ue.da.live/some/path', { method: 'HEAD' });
+
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(await res.text(), '');
+    });
+
+    it('tells a write which of the two refusals it is', async () => {
+      const worker = await refusingWorker(
+        '../src/handlers/post.js',
+        new UpstreamError(PING, new TypeError('fetch failed')),
+      );
+      const req = new Request('https://main--site--org.ue.da.live/some/path', { method: 'POST' });
+
+      const res = await worker.fetch(req, {});
+
+      assert.strictEqual(res.status, 503);
+      assert.match(await res.text(), /could not be determined/);
+    });
+  });
+
   describe('when a handler throws', () => {
     // a throw used to reject worker.fetch, and the runtime answered a bare 500 with no CORS on it,
     // which the editor cannot read at all

--- a/test/render/metadata.test.js
+++ b/test/render/metadata.test.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { Modifiers, fetchBulkMetadata } from '../../src/render/metadata.js';
+
+const aemCtx = { previewUrl: 'https://main--site--org.aem.page' };
+
+describe('fetchBulkMetadata', () => {
+  afterEach(() => {
+    delete globalThis.fetch;
+  });
+
+  it('reads the modifier sheet', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [{ url: '/**', key: 'Title', value: 'From the sheet' }],
+    }), { status: 200 });
+
+    const modifiers = await fetchBulkMetadata(aemCtx);
+
+    assert.strictEqual(modifiers.getModifiers('/page').title, 'From the sheet');
+  });
+
+  it('has no modifiers when the sheet is not there', async () => {
+    globalThis.fetch = async () => new Response('', { status: 404 });
+
+    const modifiers = await fetchBulkMetadata(aemCtx);
+
+    assert.deepStrictEqual({ ...modifiers.getModifiers('/page') }, {});
+  });
+
+  // the sheet is optional and the page composes without it, so an origin that cannot be reached
+  // degrades the same way a 404 does rather than taking the whole read down
+  it('has no modifiers when the origin does not answer', async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError('Network connection lost');
+    };
+
+    const modifiers = await fetchBulkMetadata(aemCtx);
+
+    assert.deepStrictEqual({ ...modifiers.getModifiers('/page') }, {});
+  });
+
+  it('has no modifiers when a 200 carries no JSON', async () => {
+    globalThis.fetch = async () => new Response('<html>login</html>', { status: 200 });
+
+    const modifiers = await fetchBulkMetadata(aemCtx);
+
+    assert.deepStrictEqual({ ...modifiers.getModifiers('/page') }, {});
+  });
+
+  // `null` is the one JSON body that reaches `json.default` as a non-object
+  it('has no modifiers when a 200 carries a null body', async () => {
+    globalThis.fetch = async () => new Response('null', { status: 200 });
+
+    const modifiers = await fetchBulkMetadata(aemCtx);
+
+    assert.deepStrictEqual({ ...modifiers.getModifiers('/page') }, {});
+  });
+
+  it('is the empty modifiers that never match', () => {
+    assert.deepStrictEqual({ ...Modifiers.EMPTY.getModifiers('/page') }, {});
+  });
+});

--- a/test/responses/index.test.js
+++ b/test/responses/index.test.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { upstreamFailure } from '../../src/responses/index.js';
+import { CONTENT_STORE, PING, UpstreamError } from '../../src/utils/upstream.js';
+
+const probeFailed = () => new UpstreamError(PING, new DOMException('timed out', 'TimeoutError'));
+const storeFailed = () => new UpstreamError(CONTENT_STORE, new TypeError('Network connection lost'));
+const headFailed = () => new UpstreamError('/head.html', new TypeError('fetch failed'));
+
+describe('upstreamFailure', () => {
+  it('is a 503 whichever method asked', () => {
+    ['GET', 'HEAD', 'POST', 'OPTIONS'].forEach((method) => {
+      assert.strictEqual(upstreamFailure(storeFailed(), method).status, 503);
+    });
+  });
+
+  it('names the cause in x-error', () => {
+    const res = upstreamFailure(storeFailed(), 'GET');
+    assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+  });
+
+  it('asks the caller to retry', () => {
+    assert.ok(Number(upstreamFailure(probeFailed(), 'GET').headers.get('Retry-After')) > 0);
+  });
+
+  describe('a read', () => {
+    it('renders the store as the system that failed', async () => {
+      assert.match(await upstreamFailure(storeFailed(), 'GET').text(), /Content store unreachable/);
+    });
+
+    it('renders the store when the probe is what failed', async () => {
+      assert.match(await upstreamFailure(probeFailed(), 'GET').text(), /Content store unreachable/);
+    });
+
+    // the body is what an author reads in the editor; the header is not
+    it('renders the preview host when head.html is what failed', async () => {
+      assert.match(await upstreamFailure(headFailed(), 'GET').text(), /AEM unreachable/);
+    });
+  });
+
+  describe('a HEAD', () => {
+    it('has no body', async () => {
+      assert.strictEqual(await upstreamFailure(storeFailed(), 'HEAD').text(), '');
+    });
+
+    it('still names the cause', () => {
+      const res = upstreamFailure(probeFailed(), 'HEAD');
+      assert.strictEqual(res.headers.get('x-error'), '/ping failed: TimeoutError: timed out');
+    });
+  });
+
+  describe('a write', () => {
+    // the Universal Editor Service embeds the body verbatim in its problem+json error string
+    it('is plain text', () => {
+      const res = upstreamFailure(storeFailed(), 'POST');
+      assert.strictEqual(res.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+    });
+
+    it('says nothing was written when the store did not answer', async () => {
+      assert.match(await upstreamFailure(storeFailed(), 'POST').text(), /nothing was written/);
+    });
+
+    // which store holds the site was never settled, so the write did not even pick one
+    it('says which store was undetermined when the probe did not answer', async () => {
+      assert.match(await upstreamFailure(probeFailed(), 'POST').text(), /could not be determined/);
+    });
+  });
+});

--- a/test/routes/aem-proxy.test.js
+++ b/test/routes/aem-proxy.test.js
@@ -14,6 +14,7 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import { getDaCtx } from '../../src/utils/daCtx.js';
+import { AEM_PAGE, UpstreamError } from '../../src/utils/upstream.js';
 
 describe('AEM proxy quick-edit', () => {
   let handleAEMProxyRequest;
@@ -101,37 +102,29 @@ describe('AEM proxy when the origin does not answer', () => {
   });
 
   // this response is the whole answer for a css/js/json request, so a rejection used to reach
-  // the worker's catch and leave the browser with a bodyless 500
-  it('answers 503 instead of rejecting', async () => {
+  // the worker's catch and leave the browser with a bodyless 500. It now reports the upstream
+  // and the boundary builds the 503.
+  it('reports the upstream rather than a bare rejection', async () => {
     globalThis.fetch = async () => {
       throw new TypeError('Network connection lost');
     };
     const { req, daCtx } = stylesheet();
 
-    const res = await handleAEMProxyRequest({ req, env, daCtx });
-
-    assert.strictEqual(res.status, 503);
+    await assert.rejects(
+      () => handleAEMProxyRequest({ req, env, daCtx }),
+      (e) => e instanceof UpstreamError && e.upstream === AEM_PAGE,
+    );
   });
 
-  it('names the cause in x-error', async () => {
+  it('names the cause', async () => {
     globalThis.fetch = async () => {
       throw new TypeError('Network connection lost');
     };
     const { req, daCtx } = stylesheet();
 
-    const res = await handleAEMProxyRequest({ req, env, daCtx });
-
-    assert.strictEqual(res.headers.get('x-error'), 'aem.page failed: TypeError: Network connection lost');
-  });
-
-  it('asks the caller to retry', async () => {
-    globalThis.fetch = async () => {
-      throw new DOMException('timed out', 'TimeoutError');
-    };
-    const { req, daCtx } = stylesheet();
-
-    const res = await handleAEMProxyRequest({ req, env, daCtx });
-
-    assert.ok(Number(res.headers.get('Retry-After')) > 0);
+    await assert.rejects(
+      () => handleAEMProxyRequest({ req, env, daCtx }),
+      (e) => e.error === 'aem.page failed: TypeError: Network connection lost',
+    );
   });
 });

--- a/test/routes/aem-proxy.test.js
+++ b/test/routes/aem-proxy.test.js
@@ -82,3 +82,56 @@ describe('AEM proxy quick-edit', () => {
     assert.strictEqual(res.headers.get('Set-Cookie'), null);
   });
 });
+
+describe('AEM proxy when the origin does not answer', () => {
+  let handleAEMProxyRequest;
+  const env = { UE_HOST: 'test-host', UE_SERVICE: 'test-service' };
+  const stylesheet = () => {
+    const req = new Request('https://main--site--org.ue.da.live/styles/styles.css');
+    return { req, daCtx: getDaCtx(req) };
+  };
+
+  beforeEach(async () => {
+    const mod = await esmock('../../src/routes/aem-proxy.js');
+    handleAEMProxyRequest = mod.handleAEMProxyRequest;
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+  });
+
+  // this response is the whole answer for a css/js/json request, so a rejection used to reach
+  // the worker's catch and leave the browser with a bodyless 500
+  it('answers 503 instead of rejecting', async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError('Network connection lost');
+    };
+    const { req, daCtx } = stylesheet();
+
+    const res = await handleAEMProxyRequest({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 503);
+  });
+
+  it('names the cause in x-error', async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError('Network connection lost');
+    };
+    const { req, daCtx } = stylesheet();
+
+    const res = await handleAEMProxyRequest({ req, env, daCtx });
+
+    assert.strictEqual(res.headers.get('x-error'), 'aem.page failed: TypeError: Network connection lost');
+  });
+
+  it('asks the caller to retry', async () => {
+    globalThis.fetch = async () => {
+      throw new DOMException('timed out', 'TimeoutError');
+    };
+    const { req, daCtx } = stylesheet();
+
+    const res = await handleAEMProxyRequest({ req, env, daCtx });
+
+    assert.ok(Number(res.headers.get('Retry-After')) > 0);
+  });
+});

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -107,18 +107,21 @@ describe('daSourceGet', () => {
   let calls;
 
   const mockDaSourceGet = async (overrides = {}) => {
-    // 'headHtml' in overrides (rather than a destructured default) so passing
-    // `{ headHtml: undefined }` actually simulates a missing head.html, instead
-    // of being masked by the default parameter value.
-    const headHtml = 'headHtml' in overrides ? overrides.headHtml : '<meta name="from" content="aem" />';
+    // `head` is a function so a test can make head.html answer a status or fail outright
+    const head = overrides.head
+      ?? (() => ({ status: 200, html: '<meta name="from" content="aem" />' }));
+    const store = overrides.store ?? (() => new Response('<body>stored</body>', { status: 200 }));
     calls = { compose: [], ue: 0, quickEdit: 0 };
     return (await esmock('../../src/routes/da-admin.js', {
       '../../src/storage/source-bus.js': {
         default: async () => false,
       },
+      '../../src/storage/store.js': {
+        default: () => ({ url: new URL('https://admin.da.live/source/org/site/folder/content.html'), fetch: async () => store() }),
+      },
       '../../src/utils/aemCtx.js': {
         getAemCtx: () => ({}),
-        getAEMHtml: async () => headHtml,
+        getAEMHtml: async () => head(),
       },
       '../../src/render/compose.js': {
         composeHtml: async (daCtx, aemCtx, bodyHtml) => {
@@ -233,8 +236,11 @@ describe('daSourceGet', () => {
     assert.strictEqual(await res.text(), '<html>composed</html>');
   });
 
-  it('returns a working 404 shell for quick-edit when head.html is missing', async () => {
-    const daSourceGet = await mockDaSourceGet({ headHtml: undefined });
+  it('returns a working 404 shell for quick-edit when the branch has nothing at all', async () => {
+    const daSourceGet = await mockDaSourceGet({
+      head: () => ({ status: 404 }),
+      store: () => new Response('', { status: 404 }),
+    });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
     const daCtx = getDaCtx(req);
 
@@ -248,8 +254,11 @@ describe('daSourceGet', () => {
     assert.ok(!html.includes('Unable to retrieve AEM branch'));
   });
 
-  it('still returns branch-not-found for non-quick-edit when head.html is missing', async () => {
-    const daSourceGet = await mockDaSourceGet({ headHtml: undefined });
+  it('still returns branch-not-found for non-quick-edit when the branch has nothing at all', async () => {
+    const daSourceGet = await mockDaSourceGet({
+      head: () => ({ status: 404 }),
+      store: () => new Response('', { status: 404 }),
+    });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
     const daCtx = getDaCtx(req);
 
@@ -260,6 +269,30 @@ describe('daSourceGet', () => {
     assert.strictEqual(calls.ue, 0);
     const html = await res.text();
     assert.ok(html.includes('Unable to retrieve AEM branch'));
+  });
+
+  // the shell is an empty page, so an author whose document exists is better served by the
+  // document, unstyled, than by a scaffold that hides it
+  it('composes the stored document for quick-edit when only head.html is missing', async () => {
+    const daSourceGet = await mockDaSourceGet({ head: () => ({ status: 404 }) });
+    const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
+    const daCtx = getDaCtx(req);
+
+    const res = await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(calls.compose.length, 1);
+    assert.ok(calls.compose[0].includes('stored'));
+  });
+
+  it('still injects the quick-edit import map when only head.html is missing', async () => {
+    const daSourceGet = await mockDaSourceGet({ head: () => ({ status: 404 }) });
+    const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
+    const daCtx = getDaCtx(req);
+
+    await daSourceGet({ req, env, daCtx });
+
+    assert.strictEqual(calls.quickEdit, 1);
   });
 });
 

--- a/test/routes/da-admin.test.js
+++ b/test/routes/da-admin.test.js
@@ -64,7 +64,7 @@ const mockRoutes = async () => esmock('../../src/routes/da-admin.js', {
   },
   '../../src/utils/aemCtx.js': {
     getAemCtx: () => ({}),
-    getAEMHtml: async () => '<meta name="from" content="aem" />',
+    getAEMHtml: async () => ({ status: 200, html: '<meta name="from" content="aem" />' }),
   },
   '../../src/render/compose.js': {
     composeHtml: async () => ({ tree: true }),
@@ -103,6 +103,13 @@ describe('daSourceGet', () => {
     daadmin: { fetch: async () => new Response('<body>stored</body>', { status: 200 }) },
   };
 
+  // a store that holds nothing at this path, which is both a new document and a site that is
+  // not there; head.html is what tells the two apart
+  const emptyStore = {
+    ...env,
+    daadmin: { fetch: async () => new Response('not found', { status: 404 }) },
+  };
+
   // record which composition / instrumentation calls happen and with what
   let calls;
 
@@ -110,14 +117,10 @@ describe('daSourceGet', () => {
     // `head` is a function so a test can make head.html answer a status or fail outright
     const head = overrides.head
       ?? (() => ({ status: 200, html: '<meta name="from" content="aem" />' }));
-    const store = overrides.store ?? (() => new Response('<body>stored</body>', { status: 200 }));
     calls = { compose: [], ue: 0, quickEdit: 0 };
     return (await esmock('../../src/routes/da-admin.js', {
       '../../src/storage/source-bus.js': {
         default: async () => false,
-      },
-      '../../src/storage/store.js': {
-        default: () => ({ url: new URL('https://admin.da.live/source/org/site/folder/content.html'), fetch: async () => store() }),
       },
       '../../src/utils/aemCtx.js': {
         getAemCtx: () => ({}),
@@ -237,14 +240,11 @@ describe('daSourceGet', () => {
   });
 
   it('returns a working 404 shell for quick-edit when the branch has nothing at all', async () => {
-    const daSourceGet = await mockDaSourceGet({
-      head: () => ({ status: 404 }),
-      store: () => new Response('', { status: 404 }),
-    });
+    const daSourceGet = await mockDaSourceGet({ head: () => ({ status: 404 }) });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
     const daCtx = getDaCtx(req);
 
-    const res = await daSourceGet({ req, env, daCtx });
+    const res = await daSourceGet({ req, env: emptyStore, daCtx });
 
     assert.strictEqual(res.status, 404);
     // the heavy compose pipeline is skipped entirely for this degraded path
@@ -255,14 +255,11 @@ describe('daSourceGet', () => {
   });
 
   it('still returns branch-not-found for non-quick-edit when the branch has nothing at all', async () => {
-    const daSourceGet = await mockDaSourceGet({
-      head: () => ({ status: 404 }),
-      store: () => new Response('', { status: 404 }),
-    });
+    const daSourceGet = await mockDaSourceGet({ head: () => ({ status: 404 }) });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
     const daCtx = getDaCtx(req);
 
-    const res = await daSourceGet({ req, env, daCtx });
+    const res = await daSourceGet({ req, env: emptyStore, daCtx });
 
     assert.strictEqual(res.status, 404);
     assert.strictEqual(calls.compose.length, 0);

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -703,12 +703,13 @@ describe('reading from the store that holds the site', () => {
       assert.strictEqual(await res.text(), 'upstream said no');
     });
 
-    it('reports head.html when it is the only one that did not answer', async () => {
+    it('reports head.html when the store has nothing either', async () => {
       const { daSourceGet, env } = await build({
         onSourceBus: true,
         head: () => {
           throw new UpstreamError('/head.html', new TypeError('fetch failed'));
         },
+        bus: () => new Response('', { status: 404 }),
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
@@ -716,6 +717,104 @@ describe('reading from the store that holds the site', () => {
         () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
         refuses('/head.html', '/head.html failed: TypeError: fetch failed'),
       );
+    });
+  });
+
+  // the document is in the store, so head.html's own status does not stop it being served,
+  // composed without the project head entries as on a 404
+  describe('a document the store has, with head.html unusable', () => {
+    const doc = () => new Response('<body>from the source bus</body>', { status: 200 });
+
+    [429, 500, 502, 204].forEach((status) => {
+      it(`serves the document when head.html answered ${status}`, async () => {
+        const { daSourceGet, env, seen } = await build({
+          onSourceBus: true,
+          bus: doc,
+          head: () => ({ status }),
+        });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, 200);
+        assert.match(await res.text(), /from the source bus/);
+        assert.deepStrictEqual(seen.composedHead, [undefined]);
+      });
+    });
+
+    it('serves the document when head.html did not answer at all', async () => {
+      const { daSourceGet, env, seen } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 200);
+      assert.deepStrictEqual(seen.composedHead, [undefined]);
+    });
+
+    it('names what happened to head.html in x-error', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => ({ status: 429 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), '/head.html answered 429');
+    });
+
+    it('names an unreachable head.html too', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), '/head.html failed: TypeError: fetch failed');
+    });
+
+    // the authorbus extension refreshes the token off the da:401 shell, and a head-less page
+    // would leave the author with no way to refresh it
+    [401, 403].forEach((status) => {
+      it(`still answers a head.html ${status} with the da:401 shell`, async () => {
+        const { daSourceGet, env } = await build({
+          onSourceBus: true,
+          bus: doc,
+          head: () => ({ status }),
+        });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, status);
+        assert.match(await res.text(), /da:401/);
+      });
+    });
+
+    it('still instruments the canvas for UE', async () => {
+      const { daSourceGet, env, seen } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => ({ status: 500 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(seen.ue, 1);
     });
   });
 
@@ -803,11 +902,12 @@ describe('reading from the store that holds the site', () => {
 
     // a 429 or a 502 from aem.page says nothing about the branch, and answering 404 told the
     // author their site was gone
-    [401, 403, 429, 500, 502].forEach((status) => {
-      it(`keeps head.html's ${status} as the status`, async () => {
+    [429, 500, 502].forEach((status) => {
+      it(`keeps head.html's ${status} as the status when the store has nothing`, async () => {
         const { daSourceGet, env } = await build({
           onSourceBus: true,
           head: () => ({ status }),
+          bus: () => new Response('', { status: 404 }),
         });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
@@ -819,7 +919,11 @@ describe('reading from the store that holds the site', () => {
 
     it('names head.html in x-error on a pass-through status', async () => {
       const head = () => ({ status: 429 });
-      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head,
+        bus: () => new Response('', { status: 404 }),
+      });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
@@ -845,7 +949,11 @@ describe('reading from the store that holds the site', () => {
     // a branch that is missing, so quick-edit sees it now
     it('gives quick-edit the head status rather than the shell on a 429', async () => {
       const head = () => ({ status: 429 });
-      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head,
+        bus: () => new Response('', { status: 404 }),
+      });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
@@ -938,7 +1046,11 @@ describe('reading from the store that holds the site', () => {
     [204, 205, 304].forEach((status) => {
       it(`answers ${status} without a body`, async () => {
         const head = () => ({ status });
-        const { daSourceGet, env } = await build({ onSourceBus: true, head });
+        const { daSourceGet, env } = await build({
+          onSourceBus: true,
+          head,
+          bus: () => new Response('', { status: 404 }),
+        });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
         const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
@@ -950,7 +1062,11 @@ describe('reading from the store that holds the site', () => {
 
     it('still names head.html in x-error', async () => {
       const head = () => ({ status: 204 });
-      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head,
+        bus: () => new Response('', { status: 404 }),
+      });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -871,6 +871,19 @@ describe('reading from the store that holds the site', () => {
       assert.match(await res.text(), /da:401/);
     });
 
+    // on main any non-ok head.html gave quick-edit its shell. a status that says "retry" is not
+    // a branch that is missing, so quick-edit sees it now
+    it('gives quick-edit the head status rather than the shell on a 429', async () => {
+      const head = () => ({ status: 429 });
+      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 429);
+      assert.doesNotMatch(await res.text(), /importmap/);
+    });
+
     // the store answered first and its status is about the document, which is the more specific
     // thing to report
     it('lets a store refusal outrank a head.html refusal', async () => {

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -14,7 +14,13 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import { getDaCtx } from '../../src/utils/daCtx.js';
-import { UpstreamError } from '../../src/utils/upstream.js';
+import { CONTENT_STORE, PING, UpstreamError } from '../../src/utils/upstream.js';
+
+// the routes throw; the 503 itself is built once, at the worker boundary, and is covered in
+// test/responses/index.test.js
+const refuses = (upstream, error) => (e) => e instanceof UpstreamError
+  && e.upstream === upstream
+  && (error === undefined || e.error === error);
 
 const authedReq = (url) => new Request(url, { headers: { Authorization: 'Bearer t' } });
 
@@ -90,68 +96,41 @@ describe('when /ping cannot say which store holds the site', () => {
 
   // picking a store without an answer is a coin flip, and reading the wrong one hands the author
   // the wrong document at 200
-  it('refuses an html read with 503 and touches neither store', async () => {
+  it('refuses an html read and touches neither store', async () => {
     const { daSourceGet, env, seen } = await build({ onSourceBus: undefined });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.status, 503);
+    await assert.rejects(
+      () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+      refuses(PING),
+    );
     assert.strictEqual(seen.bus.length + seen.legacy.length, 0);
-  });
-
-  it('asks the caller to retry', async () => {
-    const { daSourceGet, env } = await build({ onSourceBus: undefined });
-    const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.ok(Number(res.headers.get('Retry-After')) > 0);
   });
 
   it('refuses a non-html read too', async () => {
     const { daSourceGet, env, seen } = await build({ onSourceBus: undefined });
     const req = authedReq('https://main--site--org.ue.da.live/folder/photo.png');
 
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.status, 503);
+    await assert.rejects(
+      () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+      refuses(PING),
+    );
     assert.strictEqual(seen.bus.length + seen.legacy.length, 0);
   });
 
-  it('refuses a HEAD with 503 and no body', async () => {
+  it('refuses a HEAD too', async () => {
     const { daSourceHead, env, seen } = await build({ onSourceBus: undefined });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-    const res = await daSourceHead({ env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.status, 503);
-    assert.strictEqual(await res.text(), '');
+    await assert.rejects(
+      () => daSourceHead({ env, daCtx: getDaCtx(req) }),
+      refuses(PING),
+    );
     assert.strictEqual(seen.bus.length + seen.legacy.length, 0);
   });
 
-  // both 503s carry the same status and a body nobody parses, so the header is what tells an
-  // unanswerable probe apart from a store that was picked and then failed
-  it('names the failed probe in x-error', async () => {
-    const { daSourceGet, env } = await build({ onSourceBus: undefined });
-    const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.match(res.headers.get('x-error'), /ping/);
-  });
-
-  it('names the failed probe on a HEAD too', async () => {
-    const { daSourceHead, env } = await build({ onSourceBus: undefined });
-    const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-    const res = await daSourceHead({ env, daCtx: getDaCtx(req) });
-
-    assert.match(res.headers.get('x-error'), /ping/);
-  });
-
-  // a read answers the same 503 and the same body whichever of the two failed, so the header is
-  // the only thing on the wire that separates a timeout from a dropped connection
+  // a read fails the same way whichever of the two did not answer, so which upstream is named is
+  // the only thing that separates them
   it('carries the probe cause, not a category', async () => {
     const { daSourceGet, env } = await build({
       onSourceBus: undefined,
@@ -159,9 +138,10 @@ describe('when /ping cannot say which store holds the site', () => {
     });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.headers.get('x-error'), '/ping failed: TimeoutError: timed out');
+    await assert.rejects(
+      () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+      refuses(PING, '/ping failed: TimeoutError: timed out'),
+    );
   });
 
   // rendering a thrown non-Error as "undefined: undefined" would leave the 503 saying nothing
@@ -169,10 +149,10 @@ describe('when /ping cannot say which store holds the site', () => {
     const { daSourceGet, env } = await build({ onSourceBus: undefined, probeError: 'boom' });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.status, 503);
-    assert.strictEqual(res.headers.get('x-error'), '/ping failed: Error: boom');
+    await assert.rejects(
+      () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+      refuses(PING, '/ping failed: Error: boom'),
+    );
   });
 
   it('tells a probe failure apart from a store failure', async () => {
@@ -182,9 +162,10 @@ describe('when /ping cannot say which store holds the site', () => {
     });
     const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-    const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-    assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: fetch failed');
+    await assert.rejects(
+      () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+      refuses(CONTENT_STORE, 'content store failed: TypeError: fetch failed'),
+    );
   });
 });
 
@@ -250,136 +231,51 @@ describe('reading from the store that holds the site', () => {
   });
 
   describe('when the store cannot be reached at all', () => {
-    it('answers 503 rather than throwing on an html read', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
+    const dropped = () => {
+      throw new TypeError('Network connection lost');
+    };
+
+    it('refuses an html read', async () => {
+      const { daSourceGet, env } = await build({ onSourceBus: true, bus: dropped });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TypeError: Network connection lost'),
+      );
     });
 
-    it('answers 503 rather than throwing on a non-html read', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
+    it('refuses a non-html read', async () => {
+      const { daSourceGet, env } = await build({ onSourceBus: true, bus: dropped });
       const req = authedReq('https://main--site--org.ue.da.live/folder/photo.png');
 
-      assert.strictEqual((await daSourceGet({ req, env, daCtx: getDaCtx(req) })).status, 503);
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TypeError: Network connection lost'),
+      );
     });
 
-    it('answers 503 rather than throwing on a HEAD', async () => {
-      const { daSourceHead, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      assert.strictEqual((await daSourceHead({ env, daCtx: getDaCtx(req) })).status, 503);
-    });
-
-    it('answers 503 rather than throwing when da-admin is unreachable', async () => {
-      const { daSourceGet, env } = await build({
-        legacy: () => { throw new TypeError('fetch failed'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      assert.strictEqual((await daSourceGet({ req, env, daCtx: getDaCtx(req) })).status, 503);
-    });
-
-    it('asks the caller to retry', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.ok(Number(res.headers.get('Retry-After')) > 0);
-    });
-
-    // the read refusals are rendered, by the preview iframe and by quick-edit, so they carry a
-    // body that says what happened rather than an empty page
-    it('says what happened, on both GET paths', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
-      const html = authedReq('https://main--site--org.ue.da.live/folder/content');
-      const asset = authedReq('https://main--site--org.ue.da.live/folder/photo.png');
-
-      const htmlRes = await daSourceGet({ req: html, env, daCtx: getDaCtx(html) });
-      const assetRes = await daSourceGet({ req: asset, env, daCtx: getDaCtx(asset) });
-
-      assert.match(await htmlRes.text(), /503/);
-      assert.match(await assetRes.text(), /503/);
-    });
-
-    it('answers 503 with no body on a HEAD', async () => {
-      const { daSourceHead, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceHead({ env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(await res.text(), '');
-      assert.ok(Number(res.headers.get('Retry-After')) > 0);
-    });
-
-    // a rate limit, a DNS failure and a timeout all arrive here as the same 503, and the worker
-    // log is not where the caller is looking
-    it('names the cause in x-error on an html read', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('Network connection lost'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
-    });
-
-    it('names the cause on a non-html read', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('Network connection lost'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/photo.png');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
-    });
-
-    it('names the cause on a HEAD', async () => {
+    it('refuses a HEAD', async () => {
       const { daSourceHead, env } = await build({
         onSourceBus: true,
         bus: () => { throw new DOMException('The operation timed out', 'TimeoutError'); },
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceHead({ env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TimeoutError: The operation timed out');
+      await assert.rejects(
+        () => daSourceHead({ env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TimeoutError: The operation timed out'),
+      );
     });
 
-    it('names the cause when da-admin is unreachable', async () => {
-      const { daSourceGet, env } = await build({
-        legacy: () => { throw new TypeError('Network connection lost'); },
-      });
+    it('refuses a read when da-admin is unreachable', async () => {
+      const { daSourceGet, env } = await build({ legacy: dropped });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TypeError: Network connection lost'),
+      );
     });
 
     // a header value cannot span lines, so a message carrying a stack would throw where the 503
@@ -391,9 +287,10 @@ describe('reading from the store that holds the site', () => {
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: lost at fetch');
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TypeError: lost at fetch'),
+      );
     });
   });
 
@@ -702,9 +599,10 @@ describe('reading from the store that holds the site', () => {
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/clip.mp4');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE),
+      );
     });
 
     it('reads a video from the source bus on a source-bus site', async () => {
@@ -730,10 +628,10 @@ describe('reading from the store that holds the site', () => {
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses(CONTENT_STORE, 'content store failed: TypeError: Network connection lost'),
+      );
     });
 
     it('reports head.html when it is the only one that did not answer', async () => {
@@ -745,10 +643,10 @@ describe('reading from the store that holds the site', () => {
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
-      assert.strictEqual(res.headers.get('x-error'), '/head.html failed: TypeError: fetch failed');
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses('/head.html', '/head.html failed: TypeError: fetch failed'),
+      );
     });
   });
 
@@ -940,8 +838,8 @@ describe('reading from the store that holds the site', () => {
     });
 
     // the template is fetched from the same host head.html came from, so a host that stops
-    // answering mid-request is the same 503 rather than a blank page at 200
-    it('answers 503 when the configured template cannot be fetched', async () => {
+    // answering mid-request is refused rather than handed a blank page at 200
+    it('refuses when the configured template cannot be fetched', async () => {
       const { daSourceGet, env } = await build({
         onSourceBus: true,
         bus: absent,
@@ -955,10 +853,10 @@ describe('reading from the store that holds the site', () => {
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
-      assert.strictEqual(res.headers.get('x-error'), '/templates/basic failed: TypeError: Network connection lost');
+      await assert.rejects(
+        () => daSourceGet({ req, env, daCtx: getDaCtx(req) }),
+        refuses('/templates/basic', '/templates/basic failed: TypeError: Network connection lost'),
+      );
     });
   });
 
@@ -986,44 +884,6 @@ describe('reading from the store that holds the site', () => {
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
       assert.strictEqual(res.headers.get('x-error'), '/head.html answered 204');
-    });
-  });
-
-  // the body is what an author reads in the editor; the header is not
-  describe('which system the 503 body names', () => {
-    it('names the preview host when head.html is what did not answer', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        head: () => {
-          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
-        },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.match(await res.text(), /AEM unreachable/);
-    });
-
-    it('names the store when the store is what did not answer', async () => {
-      const { daSourceGet, env } = await build({
-        onSourceBus: true,
-        bus: () => { throw new TypeError('fetch failed'); },
-      });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.match(await res.text(), /Content store unreachable/);
-    });
-
-    it('names the store when the probe is what did not answer', async () => {
-      const { daSourceGet, env } = await build({ onSourceBus: undefined });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
-
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
-
-      assert.match(await res.text(), /Content store unreachable/);
     });
   });
 });

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -543,9 +543,9 @@ describe('reading from the store that holds the site', () => {
         assert.strictEqual(await raced(handler, 200, 404), 200);
       });
 
-      // the reason an undetermined store answers 503 rather than throwing: allSettled turns a
-      // rejection into "no answer" and the proxy's 404 would win, claiming the image is absent
-      it(`answers 503 when the store is undetermined on a ${handler.toUpperCase()}`, async () => {
+      // allSettled turns a rejection into "no answer", so the race rethrows rather than let the
+      // proxy's 404 win and claim the image is absent
+      it(`propagates an unreachable store on a ${handler.toUpperCase()}`, async () => {
         const mod = await esmock(`../../src/handlers/${handler}.js`, {
           '../../src/routes/da-admin.js': {
             daSourceGet: async () => { throw new TypeError('fetch failed'); },
@@ -557,10 +557,11 @@ describe('reading from the store that holds the site', () => {
         });
         const req = authedReq('https://main--site--org.ue.da.live/folder/photo.png');
 
-        const thrown = (await mod.default({ req, env: {}, daCtx: getDaCtx(req) })).status;
-
-        assert.strictEqual(thrown, 404, 'a rejection is swallowed and the proxy answers');
-        assert.strictEqual(await raced(handler, 503, 404), 503, 'a 503 response is not');
+        await assert.rejects(
+          () => mod.default({ req, env: {}, daCtx: getDaCtx(req) }),
+          (e) => e instanceof TypeError,
+        );
+        assert.strictEqual(await raced(handler, 503, 404), 503, 'a 503 response still wins too');
       });
     });
 

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -38,6 +38,8 @@ const build = async (overrides = {}) => {
   // does simulate a probe that could not answer
   const head = overrides.head
     ?? (() => ({ status: 200, html: '<meta name="from" content="aem" />' }));
+  // getAEMHtml sets html only on a 200. the mocks hand it over on any status, so a test that
+  // reads what compose was given tests the route, not the mock
   const onSourceBus = 'onSourceBus' in overrides ? overrides.onSourceBus : false;
   const probeError = 'probeError' in overrides ? overrides.probeError : new TypeError('fetch failed');
   const seen = {
@@ -730,7 +732,7 @@ describe('reading from the store that holds the site', () => {
         const { daSourceGet, env, seen } = await build({
           onSourceBus: true,
           bus: doc,
-          head: () => ({ status }),
+          head: () => ({ status, html: '<meta name="from" content="aem" />' }),
         });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
@@ -793,7 +795,7 @@ describe('reading from the store that holds the site', () => {
         const { daSourceGet, env } = await build({
           onSourceBus: true,
           bus: doc,
-          head: () => ({ status }),
+          head: () => ({ status, html: '<meta name="from" content="aem" />' }),
         });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
@@ -802,6 +804,36 @@ describe('reading from the store that holds the site', () => {
         assert.strictEqual(res.status, status);
         assert.match(await res.text(), /da:401/);
       });
+    });
+
+    [205, 304].forEach((status) => {
+      it(`serves the document when head.html answered ${status}`, async () => {
+        const { daSourceGet, env } = await build({
+          onSourceBus: true,
+          bus: doc,
+          head: () => ({ status, html: '<meta name="from" content="aem" />' }),
+        });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, 200);
+        assert.match(await res.text(), /from the source bus/);
+      });
+    });
+
+    it('gives quick-edit the document rather than the head status', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => ({ status: 429 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 200);
+      assert.match(await res.text(), /from the source bus/);
     });
 
     it('still instruments the canvas for UE', async () => {
@@ -815,6 +847,82 @@ describe('reading from the store that holds the site', () => {
       await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
       assert.strictEqual(seen.ue, 1);
+    });
+  });
+
+  describe('what x-error says about head.html', () => {
+    const doc = () => new Response('<body>from the source bus</body>', { status: 200 });
+
+    // a site that serves content without exposing head.html is what #258 is for, so a 404
+    // from it is an answer rather than a fault
+    it('says nothing when head.html is simply not there', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => ({ status: 404 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), null);
+    });
+
+    it('says nothing on a store refusal when head.html is simply not there', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: () => new Response('slow down', { status: 429 }),
+        head: () => ({ status: 404 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), null);
+    });
+
+    // this is the exit that dropped the note it had just logged
+    it('names head.html on the da:401 shell it triggers', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => ({ status: 403 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), '/head.html answered 403');
+    });
+
+    // rewrapping the store's response to add the header dropped its reason phrase
+    it('keeps the store statusText when it adds the header', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: () => new Response('slow down', { status: 429, statusText: 'Too Many Requests' }),
+        head: () => ({ status: 500 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.statusText, 'Too Many Requests');
+    });
+
+    // a plain Error has no `error` field, and reading that field left the 503 saying nothing
+    it('names a rejection that is not an UpstreamError', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: doc,
+        head: () => {
+          throw new TypeError('boom');
+        },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), 'TypeError: boom');
     });
   });
 
@@ -902,11 +1010,11 @@ describe('reading from the store that holds the site', () => {
 
     // a 429 or a 502 from aem.page says nothing about the branch, and answering 404 told the
     // author their site was gone
-    [429, 500, 502].forEach((status) => {
+    [401, 403, 429, 500, 502].forEach((status) => {
       it(`keeps head.html's ${status} as the status when the store has nothing`, async () => {
         const { daSourceGet, env } = await build({
           onSourceBus: true,
-          head: () => ({ status }),
+          head: () => ({ status, html: '<meta name="from" content="aem" />' }),
           bus: () => new Response('', { status: 404 }),
         });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
@@ -935,7 +1043,7 @@ describe('reading from the store that holds the site', () => {
     // Helix auth answers 403
     [401, 403].forEach((status) => {
       it(`answers a ${status} with the shell the authorbus extension matches`, async () => {
-        const head = () => ({ status });
+        const head = () => ({ status, html: '<meta name="from" content="aem" />' });
         const { daSourceGet, env } = await build({ onSourceBus: true, head });
         const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
@@ -1045,7 +1153,7 @@ describe('reading from the store that holds the site', () => {
   describe('a head.html status that forbids a body', () => {
     [204, 205, 304].forEach((status) => {
       it(`answers ${status} without a body`, async () => {
-        const head = () => ({ status });
+        const head = () => ({ status, html: '<meta name="from" content="aem" />' });
         const { daSourceGet, env } = await build({
           onSourceBus: true,
           head,

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -64,7 +64,7 @@ const build = async (overrides = {}) => {
     },
     '../../src/utils/aemCtx.js': {
       getAemCtx: () => ({}),
-      getAEMHtml: async () => head(),
+      getAEMHtml: async (ctx, path) => head(path),
     },
     '../../src/render/compose.js': {
       composeHtml: async (daCtx, aemCtx, bodyHtml) => ({ bodyHtml }),
@@ -74,7 +74,7 @@ const build = async (overrides = {}) => {
       applyUEInstrumentation: async () => { seen.ue += 1; },
     },
     '../../src/storage/config.js': {
-      getSiteConfig: async () => { throw new Error('no config'); },
+      getSiteConfig: overrides.siteConfig ?? (async () => { throw new Error('no config'); }),
     },
   });
   return { ...mod, env, seen };
@@ -539,7 +539,7 @@ describe('reading from the store that holds the site', () => {
         '../../src/storage/source-bus.js': { default: async () => true },
         '../../src/utils/aemCtx.js': {
           getAemCtx: () => ({ ueHostname: 'ue.da.live', previewUrl: 'https://p.example' }),
-          getAEMHtml: async () => '<meta name="from" content="aem" />',
+          getAEMHtml: async () => ({ status: 200, html: '<meta name="from" content="aem" />' }),
         },
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
@@ -872,6 +872,68 @@ describe('reading from the store that holds the site', () => {
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
       assert.strictEqual(res.status, 500);
+    });
+  });
+
+  // a configured starter template is fetched from the preview host like head.html is
+  describe('the configured page template', () => {
+    const absent = () => new Response('', { status: 404 });
+    const configured = async () => [{ key: 'editor.ue.template', value: '/folder=/templates/basic' }];
+    const template = '<body><main><div>from the template</div></main></body>';
+
+    it('composes the configured template for a document that is not there yet', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: absent,
+        head: (path) => (path === '/templates/basic'
+          ? { status: 200, html: template }
+          : { status: 200, html: '<meta name="from" content="aem" />' }),
+        siteConfig: configured,
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.match(await res.text(), /from the template/);
+    });
+
+    it('falls back to the starter template when the configured one is not there', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: absent,
+        head: (path) => (path === '/templates/basic'
+          ? { status: 404 }
+          : { status: 200, html: '<meta name="from" content="aem" />' }),
+        siteConfig: configured,
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 200);
+      assert.doesNotMatch(await res.text(), /from the template/);
+    });
+
+    // the template is fetched from the same host head.html came from, so a host that stops
+    // answering mid-request is the same 503 rather than a blank page at 200
+    it('answers 503 when the configured template cannot be fetched', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: absent,
+        head: (path) => {
+          if (path === '/templates/basic') {
+            throw new UpstreamError(path, new TypeError('Network connection lost'));
+          }
+          return { status: 200, html: '<meta name="from" content="aem" />' };
+        },
+        siteConfig: configured,
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(res.headers.get('x-error'), '/templates/basic failed: TypeError: Network connection lost');
     });
   });
 });

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -14,6 +14,7 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import { getDaCtx } from '../../src/utils/daCtx.js';
+import { UpstreamError } from '../../src/utils/upstream.js';
 
 const authedReq = (url) => new Request(url, { headers: { Authorization: 'Bearer t' } });
 
@@ -27,9 +28,10 @@ const build = async (overrides = {}) => {
     bus = () => new Response('<body>from the source bus</body>', { status: 200, headers: { etag: '"busetag"' } }),
     legacy = () => new Response('<body>from da-admin</body>', { status: 200 }),
   } = overrides;
-  // `in overrides` rather than a destructured default on these two, so passing an explicit
-  // undefined really does simulate a missing head.html and a probe that could not answer
-  const headHtml = 'headHtml' in overrides ? overrides.headHtml : '<meta name="from" content="aem" />';
+  // `in overrides` rather than a destructured default, so passing an explicit undefined really
+  // does simulate a probe that could not answer
+  const head = overrides.head
+    ?? (() => ({ status: 200, html: '<meta name="from" content="aem" />' }));
   const onSourceBus = 'onSourceBus' in overrides ? overrides.onSourceBus : false;
   const probeError = 'probeError' in overrides ? overrides.probeError : new TypeError('fetch failed');
   const seen = {
@@ -62,7 +64,7 @@ const build = async (overrides = {}) => {
     },
     '../../src/utils/aemCtx.js': {
       getAemCtx: () => ({}),
-      getAEMHtml: async () => headHtml,
+      getAEMHtml: async () => head(),
     },
     '../../src/render/compose.js': {
       composeHtml: async (daCtx, aemCtx, bodyHtml) => ({ bodyHtml }),
@@ -179,7 +181,7 @@ describe('when /ping cannot say which store holds the site', () => {
 
     const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-    assert.strictEqual(res.headers.get('x-error'), 'TypeError: fetch failed');
+    assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: fetch failed');
   });
 });
 
@@ -339,7 +341,7 @@ describe('reading from the store that holds the site', () => {
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TypeError: Network connection lost');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
     });
 
     it('names the cause on a non-html read', async () => {
@@ -351,7 +353,7 @@ describe('reading from the store that holds the site', () => {
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TypeError: Network connection lost');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
     });
 
     it('names the cause on a HEAD', async () => {
@@ -363,7 +365,7 @@ describe('reading from the store that holds the site', () => {
 
       const res = await daSourceHead({ env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TimeoutError: The operation timed out');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TimeoutError: The operation timed out');
     });
 
     it('names the cause when da-admin is unreachable', async () => {
@@ -374,7 +376,7 @@ describe('reading from the store that holds the site', () => {
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TypeError: Network connection lost');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
     });
 
     // a header value cannot span lines, so a message carrying a stack would throw where the 503
@@ -388,7 +390,7 @@ describe('reading from the store that holds the site', () => {
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TypeError: lost at fetch');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: lost at fetch');
     });
   });
 
@@ -713,18 +715,163 @@ describe('reading from the store that holds the site', () => {
   });
 
   describe('the order of the two things that can fail', () => {
-    // a missing AEM branch is answered as it was before, so quick-edit still gets its shell
-    it('reports a missing AEM branch even when the store did not answer', async () => {
+    // the store holds the document, so a store that did not answer is the thing to report; a
+    // head.html the same request could not read says nothing about whether the document is there
+    it('reports the store when neither the store nor head.html answered', async () => {
       const { daSourceGet, env } = await build({
         onSourceBus: true,
-        headHtml: undefined,
-        bus: () => { throw new TypeError('fetch failed'); },
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+        bus: () => { throw new TypeError('Network connection lost'); },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+    });
+
+    it('reports head.html when it is the only one that did not answer', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 503);
+      assert.strictEqual(res.headers.get('x-error'), '/head.html failed: TypeError: fetch failed');
+    });
+  });
+
+  // adobe/da-universal#258. head.html carries the project's scripts and styles, not the answer to
+  // whether the document exists, so a site that serves content without exposing head.html is read
+  describe('what a head.html status means', () => {
+    const missingHead = () => ({ status: 404 });
+
+    it('serves the stored document when head.html is a 404', async () => {
+      const { daSourceGet, env } = await build({ onSourceBus: true, head: missingHead });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 200);
+      assert.match(await res.text(), /from the source bus/);
+    });
+
+    it('composes without the project head entries', async () => {
+      const { daSourceGet, env } = await build({ onSourceBus: true, head: missingHead });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.doesNotMatch(await res.text(), /content="aem"/);
+    });
+
+    it('still instruments the canvas for UE', async () => {
+      const { daSourceGet, env, seen } = await build({ onSourceBus: true, head: missingHead });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(seen.ue, 1);
+    });
+
+    it('serves the document on a legacy site too', async () => {
+      const { daSourceGet, env } = await build({ head: missingHead });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 200);
+      assert.match(await res.text(), /from da-admin/);
+    });
+
+    // head.html is the only thing on this path that knows whether the site is there at all, so
+    // a typo'd site must not answer 200 with a blank canvas an author can save over
+    it('reports a missing branch when neither the store nor head.html has anything', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: missingHead,
+        bus: () => new Response('', { status: 404 }),
       });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
       const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
       assert.strictEqual(res.status, 404);
+      assert.match(await res.text(), /Unable to retrieve AEM branch/);
+    });
+
+    it('gives quick-edit its shell when neither has anything', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: missingHead,
+        bus: () => new Response('', { status: 404 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content?quick-edit');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 404);
+      assert.match(await res.text(), /importmap/);
+    });
+
+    // a 429 or a 502 from aem.page says nothing about the branch, and answering 404 told the
+    // author their site was gone
+    [401, 403, 429, 500, 502].forEach((status) => {
+      it(`keeps head.html's ${status} as the status`, async () => {
+        const { daSourceGet, env } = await build({
+          onSourceBus: true,
+          head: () => ({ status }),
+        });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, status);
+      });
+    });
+
+    it('names head.html in x-error on a pass-through status', async () => {
+      const head = () => ({ status: 429 });
+      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), '/head.html answered 429');
+    });
+
+    // the authorbus extension recovers off the da:401 meta rather than the status
+    it('answers a refusal with the shell the authorbus extension matches', async () => {
+      const head = () => ({ status: 401 });
+      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.match(await res.text(), /da:401/);
+    });
+
+    // the store answered first and its status is about the document, which is the more specific
+    // thing to report
+    it('lets a store refusal outrank a head.html refusal', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => ({ status: 429 }),
+        bus: () => new Response('', { status: 500 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 500);
     });
   });
 });

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -635,6 +635,39 @@ describe('reading from the store that holds the site', () => {
       );
     });
 
+    // an unreadable head.html says nothing about the store's 401, and on a 503 the da:401
+    // shell is not sent
+    it('keeps a store refusal when head.html did not answer', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+        bus: () => new Response('', { status: 401 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 401);
+      assert.match(await res.text(), /da:401/);
+    });
+
+    it('keeps a store rate limit when head.html did not answer', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+        bus: () => new Response('slow down', { status: 429 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.status, 429);
+    });
+
     it('reports head.html when it is the only one that did not answer', async () => {
       const { daSourceGet, env } = await build({
         onSourceBus: true,
@@ -759,15 +792,18 @@ describe('reading from the store that holds the site', () => {
       assert.strictEqual(res.headers.get('x-error'), '/head.html answered 429');
     });
 
-    // the authorbus extension recovers off the da:401 meta rather than the status
-    it('answers a refusal with the shell the authorbus extension matches', async () => {
-      const head = () => ({ status: 401 });
-      const { daSourceGet, env } = await build({ onSourceBus: true, head });
-      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+    // the authorbus extension recovers off the da:401 meta, not the status, and a site behind
+    // Helix auth answers 403
+    [401, 403].forEach((status) => {
+      it(`answers a ${status} with the shell the authorbus extension matches`, async () => {
+        const head = () => ({ status });
+        const { daSourceGet, env } = await build({ onSourceBus: true, head });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.match(await res.text(), /da:401/);
+        assert.match(await res.text(), /da:401/);
+      });
     });
 
     // on main any non-ok head.html gave quick-edit its shell. a status that says "retry" is not

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -668,6 +668,41 @@ describe('reading from the store that holds the site', () => {
       assert.strictEqual(res.status, 429);
     });
 
+    // the store's status is the answer, but dropping the head.html failure would hide an
+    // aem.page outage
+    [401, 429, 500].forEach((status) => {
+      it(`names the head.html failure alongside a store ${status}`, async () => {
+        const { daSourceGet, env } = await build({
+          onSourceBus: true,
+          head: () => {
+            throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+          },
+          bus: () => new Response('upstream said no', { status }),
+        });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, status);
+        assert.strictEqual(res.headers.get('x-error'), '/head.html failed: TypeError: fetch failed');
+      });
+    });
+
+    it('keeps the store body on a pass-through that also lost head.html', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+        bus: () => new Response('upstream said no', { status: 502 }),
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(await res.text(), 'upstream said no');
+    });
+
     it('reports head.html when it is the only one that did not answer', async () => {
       const { daSourceGet, env } = await build({
         onSourceBus: true,

--- a/test/routes/source-read.test.js
+++ b/test/routes/source-read.test.js
@@ -35,7 +35,7 @@ const build = async (overrides = {}) => {
   const onSourceBus = 'onSourceBus' in overrides ? overrides.onSourceBus : false;
   const probeError = 'probeError' in overrides ? overrides.probeError : new TypeError('fetch failed');
   const seen = {
-    bus: [], legacy: [], ue: 0, lookups: 0,
+    bus: [], legacy: [], ue: 0, lookups: 0, composedHead: [],
   };
   globalThis.fetch = async (input, init) => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -67,7 +67,10 @@ const build = async (overrides = {}) => {
       getAEMHtml: async (ctx, path) => head(path),
     },
     '../../src/render/compose.js': {
-      composeHtml: async (daCtx, aemCtx, bodyHtml) => ({ bodyHtml }),
+      composeHtml: async (daCtx, aemCtx, bodyHtml, headHtml) => {
+        seen.composedHead.push(headHtml);
+        return { bodyHtml };
+      },
       serializeHtml: (tree) => `<html>${tree.bodyHtml}</html>`,
     },
     '../../src/ue/ue.js': {
@@ -765,12 +768,21 @@ describe('reading from the store that holds the site', () => {
     });
 
     it('composes without the project head entries', async () => {
-      const { daSourceGet, env } = await build({ onSourceBus: true, head: missingHead });
+      const { daSourceGet, env, seen } = await build({ onSourceBus: true, head: missingHead });
       const req = authedReq('https://main--site--org.ue.da.live/folder/content');
 
-      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+      await daSourceGet({ req, env, daCtx: getDaCtx(req) });
 
-      assert.doesNotMatch(await res.text(), /content="aem"/);
+      assert.deepStrictEqual(seen.composedHead, [undefined]);
+    });
+
+    it('composes with them when head.html is there', async () => {
+      const { daSourceGet, env, seen } = await build({ onSourceBus: true });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.deepStrictEqual(seen.composedHead, ['<meta name="from" content="aem" />']);
     });
 
     it('still instruments the canvas for UE', async () => {
@@ -934,6 +946,71 @@ describe('reading from the store that holds the site', () => {
 
       assert.strictEqual(res.status, 503);
       assert.strictEqual(res.headers.get('x-error'), '/templates/basic failed: TypeError: Network connection lost');
+    });
+  });
+
+  // 204, 205 and 304 cannot carry a body, so reflecting one into a rendered page throws where
+  // the Response is built and the read comes back as the worker's bodyless 500
+  describe('a head.html status that forbids a body', () => {
+    [204, 205, 304].forEach((status) => {
+      it(`answers ${status} without a body`, async () => {
+        const head = () => ({ status });
+        const { daSourceGet, env } = await build({ onSourceBus: true, head });
+        const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+        const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+        assert.strictEqual(res.status, status);
+        assert.strictEqual(await res.text(), '');
+      });
+    });
+
+    it('still names head.html in x-error', async () => {
+      const head = () => ({ status: 204 });
+      const { daSourceGet, env } = await build({ onSourceBus: true, head });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.strictEqual(res.headers.get('x-error'), '/head.html answered 204');
+    });
+  });
+
+  // the body is what an author reads in the editor; the header is not
+  describe('which system the 503 body names', () => {
+    it('names the preview host when head.html is what did not answer', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        head: () => {
+          throw new UpstreamError('/head.html', new TypeError('fetch failed'));
+        },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.match(await res.text(), /AEM unreachable/);
+    });
+
+    it('names the store when the store is what did not answer', async () => {
+      const { daSourceGet, env } = await build({
+        onSourceBus: true,
+        bus: () => { throw new TypeError('fetch failed'); },
+      });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.match(await res.text(), /Content store unreachable/);
+    });
+
+    it('names the store when the probe is what did not answer', async () => {
+      const { daSourceGet, env } = await build({ onSourceBus: undefined });
+      const req = authedReq('https://main--site--org.ue.da.live/folder/content');
+
+      const res = await daSourceGet({ req, env, daCtx: getDaCtx(req) });
+
+      assert.match(await res.text(), /Content store unreachable/);
     });
   });
 });

--- a/test/routes/source-write.test.js
+++ b/test/routes/source-write.test.js
@@ -287,7 +287,7 @@ describe('writing to the store that holds the site', () => {
 
       const res = await daSourcePost({ req, env, daCtx: getDaCtx(req) });
 
-      assert.strictEqual(res.headers.get('x-error'), 'TypeError: Network connection lost');
+      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
     });
   });
 

--- a/test/routes/source-write.test.js
+++ b/test/routes/source-write.test.js
@@ -14,7 +14,8 @@
 import assert from 'assert';
 import esmock from 'esmock';
 import { getDaCtx } from '../../src/utils/daCtx.js';
-import { SOURCE_BUS_READ_ONLY_MESSAGE, SOURCE_UNDETERMINED_MESSAGE } from '../../src/utils/constants.js';
+import { SOURCE_BUS_READ_ONLY_MESSAGE } from '../../src/utils/constants.js';
+import { CONTENT_STORE, PING, UpstreamError } from '../../src/utils/upstream.js';
 
 const AT = 'https://main--site--org.ue.da.live/folder/content';
 const DOC = '<body><main><div><p>the author typed this</p></div></main></body>';
@@ -89,6 +90,22 @@ const post = async (opts, url = AT) => {
   return { res, seen };
 };
 
+// a write that could not reach its upstream throws; the 503 is built once, at the worker
+// boundary, and is covered in test/responses/index.test.js
+const refusedPost = async (opts, url = AT) => {
+  const { daSourcePost, env, seen } = await build(opts);
+  const req = uePost(url);
+  let failure;
+  await assert.rejects(
+    () => daSourcePost({ req, env, daCtx: getDaCtx(req) }),
+    (e) => {
+      failure = e;
+      return e instanceof UpstreamError;
+    },
+  );
+  return { failure, seen };
+};
+
 describe('writing to the store that holds the site', () => {
   afterEach(() => {
     delete globalThis.fetch;
@@ -130,39 +147,21 @@ describe('writing to the store that holds the site', () => {
   // a write is the one operation a wrong store cannot be walked back from, so no answer means no
   // write rather than a guess
   describe('when /ping cannot say which store holds the site', () => {
-    it('is refused with 503 and touches neither store', async () => {
-      const { res, seen } = await post({ onSourceBus: undefined });
+    it('is refused and touches neither store', async () => {
+      const { failure, seen } = await refusedPost({ onSourceBus: undefined });
 
-      assert.strictEqual(res.status, 503);
+      assert.strictEqual(failure.upstream, PING);
       assert.strictEqual(seen.bus.length, 0);
       assert.strictEqual(seen.legacy.length, 0);
     });
 
-    it('asks the caller to retry, unlike the source-bus refusal', async () => {
-      const { res } = await post({ onSourceBus: undefined });
-
-      assert.ok(Number(res.headers.get('Retry-After')) > 0);
-    });
-
-    it('says which of the two refusals it is', async () => {
-      const { res } = await post({ onSourceBus: undefined });
-
-      assert.strictEqual(await res.text(), SOURCE_UNDETERMINED_MESSAGE);
-    });
-
-    it('names the failed probe in x-error', async () => {
-      const { res } = await post({ onSourceBus: undefined });
-
-      assert.match(res.headers.get('x-error'), /ping/);
-    });
-
     it('carries the probe cause, not a category', async () => {
-      const { res } = await post({
+      const { failure } = await refusedPost({
         onSourceBus: undefined,
         probeError: new DOMException('timed out', 'TimeoutError'),
       });
 
-      assert.strictEqual(res.headers.get('x-error'), '/ping failed: TimeoutError: timed out');
+      assert.strictEqual(failure.error, '/ping failed: TimeoutError: timed out');
     });
   });
 
@@ -271,9 +270,10 @@ describe('writing to the store that holds the site', () => {
       };
       const req = uePost(AT);
 
-      const res = await daSourcePost({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.status, 503);
+      await assert.rejects(
+        () => daSourcePost({ req, env, daCtx: getDaCtx(req) }),
+        (e) => e instanceof UpstreamError && e.upstream === CONTENT_STORE,
+      );
     });
 
     // a save that failed on a rate limit and one that failed on a dropped connection are the same
@@ -285,9 +285,10 @@ describe('writing to the store that holds the site', () => {
       };
       const req = uePost(AT);
 
-      const res = await daSourcePost({ req, env, daCtx: getDaCtx(req) });
-
-      assert.strictEqual(res.headers.get('x-error'), 'content store failed: TypeError: Network connection lost');
+      await assert.rejects(
+        () => daSourcePost({ req, env, daCtx: getDaCtx(req) }),
+        (e) => e.error === 'content store failed: TypeError: Network connection lost',
+      );
     });
   });
 

--- a/test/utils/aemCtx.test.js
+++ b/test/utils/aemCtx.test.js
@@ -73,10 +73,10 @@ describe('AEM context', () => {
 
     beforeEach(async () => {
       // Mock global fetch
-      global.fetch = async (url) => ({
-        ok: url.includes('success'),
-        text: async () => '<html>test content</html>',
-      });
+      global.fetch = async (url) => new Response(
+        '<html>test content</html>',
+        { status: url.includes('success') ? 200 : 404 },
+      );
     });
 
     afterEach(() => {
@@ -84,13 +84,51 @@ describe('AEM context', () => {
     });
 
     it('should return HTML content for successful request', async () => {
-      const html = await getAEMHtml(mockAemCtx, '/success-path');
+      const { html } = await getAEMHtml(mockAemCtx, '/success-path');
       assert.strictEqual(html, '<html>test content</html>');
     });
 
+    it('reports the status alongside the html', async () => {
+      const { status } = await getAEMHtml(mockAemCtx, '/success-path');
+      assert.strictEqual(status, 200);
+    });
+
     it('should return undefined for failed request', async () => {
-      const html = await getAEMHtml(mockAemCtx, '/fail-path');
+      const { html } = await getAEMHtml(mockAemCtx, '/fail-path');
       assert.strictEqual(html, undefined);
+    });
+
+    // a 404 says the branch has no head.html; a 429 or a 503 says the caller should not read
+    // that as an answer about the branch at all
+    it('reports which status a refusal carried', async () => {
+      global.fetch = async () => new Response('slow down', { status: 429 });
+      const { status } = await getAEMHtml(mockAemCtx, '/any-path');
+      assert.strictEqual(status, 429);
+    });
+
+    it('throws an UpstreamError naming the path when the origin does not answer', async () => {
+      global.fetch = async () => {
+        throw new TypeError('Network connection lost');
+      };
+      await assert.rejects(
+        () => getAEMHtml(mockAemCtx, '/head.html'),
+        (e) => e.name === 'UpstreamError'
+          && e.error === '/head.html failed: TypeError: Network connection lost',
+      );
+    });
+
+    it('throws when the body cannot be read', async () => {
+      global.fetch = async () => ({
+        ok: true,
+        status: 200,
+        text: async () => {
+          throw new TypeError('Network connection lost');
+        },
+      });
+      await assert.rejects(
+        () => getAEMHtml(mockAemCtx, '/head.html'),
+        (e) => e.name === 'UpstreamError',
+      );
     });
   });
 

--- a/test/utils/aemCtx.test.js
+++ b/test/utils/aemCtx.test.js
@@ -106,6 +106,16 @@ describe('AEM context', () => {
       assert.strictEqual(status, 429);
     });
 
+    // a 2xx that is not 200 is not a head fragment
+    it('reports a 2xx that is not 200 without html', async () => {
+      global.fetch = async () => new Response('<meta name="x">', { status: 203 });
+
+      const { status, html } = await getAEMHtml(mockAemCtx, '/head.html');
+
+      assert.strictEqual(status, 203);
+      assert.strictEqual(html, undefined);
+    });
+
     it('throws an UpstreamError naming the path when the origin does not answer', async () => {
       global.fetch = async () => {
         throw new TypeError('Network connection lost');

--- a/test/utils/upstream.test.js
+++ b/test/utils/upstream.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import {
+  CONTENT_STORE, PING, UpstreamError, causeOf, reach,
+} from '../../src/utils/upstream.js';
+
+describe('causeOf', () => {
+  it('renders an error as name and message', () => {
+    assert.strictEqual(causeOf(new TypeError('fetch failed')), 'TypeError: fetch failed');
+  });
+
+  it('keeps the DOMException name a timeout arrives under', () => {
+    assert.strictEqual(causeOf(new DOMException('timed out', 'TimeoutError')), 'TimeoutError: timed out');
+  });
+
+  // a thrown string has no name, and "undefined: undefined" would leave the 503 saying nothing
+  it('renders a thrown non-Error', () => {
+    assert.strictEqual(causeOf('boom'), 'Error: boom');
+  });
+
+  // the value reaches a response header, where a newline would split it into a second header
+  it('collapses whitespace and control characters', () => {
+    assert.strictEqual(causeOf(new Error('lost\r\n at\tfetch')), 'Error: lost at fetch');
+  });
+
+  it('caps the rendered cause at 1024 characters', () => {
+    assert.strictEqual(causeOf(new Error('x'.repeat(2000))).length, 1024);
+  });
+});
+
+describe('UpstreamError', () => {
+  it('names the upstream that did not answer', () => {
+    const e = new UpstreamError(PING, new TypeError('fetch failed'));
+    assert.strictEqual(e.upstream, PING);
+  });
+
+  it('renders the header value as the upstream and the cause', () => {
+    const e = new UpstreamError(PING, new DOMException('timed out', 'TimeoutError'));
+    assert.strictEqual(e.error, '/ping failed: TimeoutError: timed out');
+  });
+
+  it('is an Error', () => {
+    assert.ok(new UpstreamError(CONTENT_STORE, new Error('x')) instanceof Error);
+  });
+});
+
+describe('reach', () => {
+  it('passes the value through when the upstream answers', async () => {
+    assert.strictEqual(await reach(CONTENT_STORE, async () => 'answer'), 'answer');
+  });
+
+  it('turns a rejection into an UpstreamError naming the upstream', async () => {
+    await assert.rejects(
+      () => reach(CONTENT_STORE, async () => { throw new TypeError('Network connection lost'); }),
+      (e) => e instanceof UpstreamError
+        && e.error === 'content store failed: TypeError: Network connection lost',
+    );
+  });
+
+  // /ping is reached through isSourceBus, which already wraps its own fetch, so a second wrap
+  // would render the header as "content store failed: UpstreamError: /ping failed: ..."
+  it('leaves an UpstreamError from a nested reach alone', async () => {
+    const inner = new UpstreamError(PING, new TypeError('fetch failed'));
+    await assert.rejects(
+      () => reach(CONTENT_STORE, async () => { throw inner; }),
+      (e) => e === inner,
+    );
+  });
+});

--- a/test/utils/upstream.test.js
+++ b/test/utils/upstream.test.js
@@ -54,6 +54,23 @@ describe('UpstreamError', () => {
   it('is an Error', () => {
     assert.ok(new UpstreamError(CONTENT_STORE, new Error('x')) instanceof Error);
   });
+
+  // one upstream names itself by a path out of the site config sheet, and a newline in that cell
+  // would throw where the header is appended, turning the 503 back into a bodyless 500
+  it('collapses whitespace in the upstream name too', () => {
+    const e = new UpstreamError('/templates/a\nx-injected: 1', new TypeError('x'));
+    assert.strictEqual(e.error, '/templates/a x-injected: 1 failed: TypeError: x');
+  });
+
+  it('caps the whole header value at 1024 characters', () => {
+    const e = new UpstreamError('/'.padEnd(900, 'a'), new Error('y'.repeat(900)));
+    assert.strictEqual(e.error.length, 1024);
+  });
+
+  it('renders a header value a Response accepts', () => {
+    const e = new UpstreamError('/t\r\n\u0000', new Error('boom'));
+    assert.doesNotThrow(() => new Response('', { headers: { 'x-error': e.error } }));
+  });
 });
 
 describe('reach', () => {


### PR DESCRIPTION
- an upstream that does not answer throws a typed error, caught once at the worker boundary and
  named in `x-error`. was a bodyless 500
- head.html no longer decides whether a document exists, so a branch without one serves the
  stored document. fixes #258
