### PR TITLE
fix: drop a csp meta the pipeline would have moved to a header

### DIFF
--- a/src/render/compose.js
+++ b/src/render/compose.js
@@ -33,6 +33,15 @@ function injectAEMHtmlHeadEntries(daCtx, headNode, headHtmlStr) {
   const { org, site, orgSiteInPath } = daCtx;
   const aemHeadHtmlTree = fromHtml(headHtmlStr, { fragment: true });
 
+  // the config service hands over head.html as the code bus holds it, so a meta the pipeline
+  // would have turned into a response header is still a meta here. Emitting it applies a CSP
+  // the page was never meant to carry, and the UE scripts injected later have no nonce.
+  aemHeadHtmlTree.children = aemHeadHtmlTree.children.filter(
+    (node) => !(node.type === 'element'
+      && node.tagName === 'meta'
+      && node.properties?.['move-to-http-header'] !== undefined),
+  );
+
   // TODO: reuse fixUrlsWhenLocalDev from aemCtx.js instead of duplicating.
   if (orgSiteInPath) {
     const headScriptsAndLinks = selectAll(

--- a/src/render/compose.js
+++ b/src/render/compose.js
@@ -33,14 +33,18 @@ function injectAEMHtmlHeadEntries(daCtx, headNode, headHtmlStr) {
   const { org, site, orgSiteInPath } = daCtx;
   const aemHeadHtmlTree = fromHtml(headHtmlStr, { fragment: true });
 
-  // the config service hands over head.html as the code bus holds it, so a meta the pipeline
-  // would have turned into a response header is still a meta here. Emitting it applies a CSP
-  // the page was never meant to carry, and the UE scripts injected later have no nonce.
+  // the pipeline moves this meta to a response header and rewrites the placeholder
+  // nonce; drop both.
   aemHeadHtmlTree.children = aemHeadHtmlTree.children.filter(
     (node) => !(node.type === 'element'
       && node.tagName === 'meta'
-      && node.properties?.['move-to-http-header'] !== undefined),
+      && node.properties?.['move-to-http-header'] !== undefined
+      && typeof node.properties?.content === 'string'
+      && node.properties.content.includes("'nonce-aem'")),
   );
+  selectAll('[nonce=aem]', aemHeadHtmlTree).forEach((n) => {
+    delete n.properties.nonce;
+  });
 
   // TODO: reuse fixUrlsWhenLocalDev from aemCtx.js instead of duplicating.
   if (orgSiteInPath) {

--- a/test/render/compose.test.js
+++ b/test/render/compose.test.js
@@ -66,4 +66,27 @@ describe('render compose', () => {
     assert.ok(!html.includes('urn:adobe:aue'));
     assert.ok(!html.includes('universal-editor-service'));
   });
+  it('drops a CSP meta the pipeline would have moved to a header', async () => {
+    const cspHead = '<meta http-equiv="Content-Security-Policy"'
+      + ' content="script-src \'nonce-aem\' \'strict-dynamic\';"'
+      + ' move-to-http-header="true" />'
+      + '<script nonce="aem" src="/scripts/aem.js" type="module"></script>';
+
+    const tree = await composeHtml(daCtx, aemCtx, '<div><p>content</p></div>', cspHead);
+    const html = serializeHtml(tree);
+
+    assert.ok(!html.includes('Content-Security-Policy'));
+    assert.ok(!html.includes('move-to-http-header'));
+    // the rest of head.html is untouched
+    assert.ok(html.includes('src="/scripts/aem.js"'));
+  });
+
+  it('keeps a CSP meta the pipeline would have left in place', async () => {
+    const cspHead = '<meta http-equiv="Content-Security-Policy" content="object-src \'none\';" />';
+
+    const tree = await composeHtml(daCtx, aemCtx, '<div><p>content</p></div>', cspHead);
+    const html = serializeHtml(tree);
+
+    assert.ok(html.includes('Content-Security-Policy'));
+  });
 });

--- a/test/render/compose.test.js
+++ b/test/render/compose.test.js
@@ -77,6 +77,7 @@ describe('render compose', () => {
 
     assert.ok(!html.includes('Content-Security-Policy'));
     assert.ok(!html.includes('move-to-http-header'));
+    assert.ok(!html.includes('nonce="aem"'));
     // the rest of head.html is untouched
     assert.ok(html.includes('src="/scripts/aem.js"'));
   });


### PR DESCRIPTION
`head.html` now comes from the config service, which serves it as the code bus holds it, so a `<meta http-equiv="Content-Security-Policy" ... move-to-http-header="true">` that the pipeline used to consume reached the composed page and blocked the un-nonced Universal Editor scripts.

Relates to #270
